### PR TITLE
GPU rewrite: N-body broadcast kernels + regime-optimal dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
@@ -21,12 +22,14 @@ OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [extensions]
+StructureFunctionsCUDAExt = ["KernelAbstractions", "CUDA"]
 StructureFunctionsCairoMakieExt = ["CairoMakie"]
 StructureFunctionsGPUExt = ["KernelAbstractions"]
 StructureFunctionsOhMyThreadsExt = ["OhMyThreads"]
 StructureFunctionsDistributedExt = ["Distributed", "SharedArrays"]
 
 [compat]
+CUDA = "5, 6"
 CairoMakie = "0.15"
 Distances = "0.10"
 Distributed = "1.11"

--- a/ext/StructureFunctionsCUDAExt.jl
+++ b/ext/StructureFunctionsCUDAExt.jl
@@ -1,0 +1,65 @@
+"""
+CUDA-specialized fast structure-function kernels.
+
+Loaded automatically when **both** `KernelAbstractions` and `CUDA` are present.
+Provides the settled-optimal GPU kernels (N-body broadcast + privatized /
+dynamic-shared histograms) for NVIDIA GPUs, overriding the portable
+KernelAbstractions tiled kernels in `StructureFunctionsGPUExt` (which remain the
+CPU/AMD reference). See `gpu/OPTIMAL_KERNEL_DESIGN.md`.
+
+These kernels use CUDA-only intrinsics not exposed by KernelAbstractions:
+`CuDynamicSharedArray` (>48 KB dynamic shared via the opt-in attribute),
+`CUDA.@atomic`, `@cuda launch=false`, and device shared-memory queries. The
+`GPUBackend{B}` wrapper is parametric precisely so the CUDA backend can take this
+specialized path while the CPU backend stays on the KA kernels.
+
+The pure, device-callable building blocks (`_sf_moments`, `_sf_dot`,
+`_gpu_digitize_value_plan`, digitizer functors, value plans) live in
+`StructureFunctionsGPUExt`; this extension reuses them via `GE` so there is a
+single source of truth for the per-pair math and binning.
+"""
+module StructureFunctionsCUDAExt
+
+using CUDA: CUDA, CuStaticSharedArray, CuDynamicSharedArray, @cuda,
+    threadIdx, blockIdx, blockDim, sync_threads
+using KernelAbstractions: KernelAbstractions as KA
+using StaticArrays: StaticArrays as SA
+using StructureFunctions: StructureFunctions as SF, Calculations as SFC
+
+# The GPU (KernelAbstractions) extension owns the shared device-callable building
+# blocks and the digitizer / value-plan types. It is triggered by
+# KernelAbstractions alone, so it is loaded whenever this extension's triggers
+# (KernelAbstractions + CUDA) are satisfied.
+const GE = let m = Base.get_extension(SF, :StructureFunctionsGPUExt)
+    m === nothing &&
+        error("StructureFunctionsCUDAExt: StructureFunctionsGPUExt must be loaded first " *
+              "(load KernelAbstractions before / with CUDA).")
+    m
+end
+
+include(joinpath(@__DIR__, "cuda", "kernels_2d.jl"))
+include(joinpath(@__DIR__, "cuda", "kernels_1d.jl"))
+
+# ---------------------------------------------------------------------------
+# Dispatch hooks (override the package stubs in src/Calculations/gpu_stubs.jl).
+# Specialized on CUDA.CUDABackend; the default methods return `false`.
+# ---------------------------------------------------------------------------
+
+function SFC.gpu_fast_launch_2d_batch!(
+    ::CUDA.CUDABackend, out, cnt, x, u, sf_type, dist_dig, val_plan,
+    N, n_dist, n_val, B, D, nmom, fixed_x,
+)
+    return _cuda_launch_2d!(out, cnt, x, u, sf_type, dist_dig, val_plan,
+                            Int(N), Int(n_dist), Int(n_val), Int(B),
+                            Int(D), Int(nmom), fixed_x)
+end
+
+function SFC.gpu_fast_launch_1d_batch!(
+    ::CUDA.CUDABackend, out, cnt, x, u, sf_type, dist_dig,
+    N, NB, B, D, nmom, fixed_x,
+)
+    return _cuda_launch_1d!(out, cnt, x, u, sf_type, dist_dig,
+                            Int(N), Int(NB), Int(B), Int(D), Int(nmom), fixed_x)
+end
+
+end # module

--- a/ext/StructureFunctionsGPUExt.jl
+++ b/ext/StructureFunctionsGPUExt.jl
@@ -36,13 +36,13 @@ GPU kernel (`LinearBinEdges`, `LogBinEdges`, or general `Vector`). Pass typed ed
 fast paths; plain `Vector` inputs use the general kernel with no layout inference.
 
 !!! note "KernelAbstractions Macro Limitations"
-    We explicitly import `@index`, `@atomic`, `@Const`, `@private`, and `@localmem` from `KernelAbstractions` because
+    We explicitly import `@index`, `@atomic`, `@Const`, `@private`, `@uniform`, and `@localmem` from `KernelAbstractions` because
     these macros currently fail to resolve correctly when called as `KA.@index`, etc.
     `@Const` is only valid on **kernel** parameter lists, not on host `@inline` helpers.
 """
 module StructureFunctionsGPUExt
 
-using KernelAbstractions: KernelAbstractions as KA, @index, @atomic, @Const, @localmem, @private, @synchronize
+using KernelAbstractions: KernelAbstractions as KA, @index, @atomic, @Const, @localmem, @private, @uniform, @synchronize
 using StaticArrays: StaticArrays as SA
 using Distances: Distances as DI
 using StructureFunctions: StructureFunctions as SF, Calculations as SFC,
@@ -166,6 +166,27 @@ end
     return low - 1
 end
 
+@inline function _gpu_digitize_general_col(
+    x::T,
+    edges,
+    col::Int,
+    n_edges::Int,
+) where {T}
+    low = 1
+    high = n_edges
+    while low <= high
+        mid = (low + high) >>> 1
+        @inbounds edge_mid = edges[mid, col]
+        if edge_mid < x
+            low = mid + 1
+        else
+            high = mid - 1
+        end
+    end
+    return low - 1
+end
+
+
 """
 Device digitize for [`InfPaddedBinEdges`](@ref) with [`LinearBinEdges`](@ref) interior.
 Matches CPU `digitize(x, InfPadded)` (underflow bin 1, interior FMA+offset, overflow past inner last).
@@ -203,7 +224,7 @@ const SF_GPU_TILE = 128
 const SF_GPU_TILED_WS = 256
 
 """Maximum distance-bin count compiled into tiled `@localmem` histograms."""
-const SF_GPU_MAX_BINS = 64
+const SF_GPU_MAX_BINS = 128
 
 """
 Maximum flat joint histogram cells ``n_dist × n_val`` for tiled128 2D joint SF
@@ -252,6 +273,10 @@ include(joinpath(@__DIR__, "gpu", "kernels_2d_single_pass.jl"))
 include(joinpath(@__DIR__, "gpu", "kernels_2d_value_axis.jl"))
 include(joinpath(@__DIR__, "gpu", "kernels_2d_direct.jl"))
 include(joinpath(@__DIR__, "gpu", "kernels_batch.jl"))
+# Unified parametric kernel core (building blocks) + the two tiled kernels that
+# replace the per-variant kernels above. See gpu/OPTIMAL_KERNEL_DESIGN.md.
+include(joinpath(@__DIR__, "gpu", "sf_core.jl"))
+include(joinpath(@__DIR__, "gpu", "sf_tiled.jl"))
 include(joinpath(@__DIR__, "gpu", "workspace.jl"))
 include(joinpath(@__DIR__, "gpu", "launch.jl"))
 
@@ -997,7 +1022,7 @@ end
     return nothing
 end
 
-KA.@kernel function _sf_single_pass_kernel_linear!(
+KA.@kernel unsafe_indices=true function _sf_single_pass_kernel_linear!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1029,7 +1054,7 @@ KA.@kernel function _sf_single_pass_kernel_linear!(
     end
 end
 
-KA.@kernel function _sf_single_pass_kernel_log!(
+KA.@kernel unsafe_indices=true function _sf_single_pass_kernel_log!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1059,7 +1084,7 @@ KA.@kernel function _sf_single_pass_kernel_log!(
     end
 end
 
-KA.@kernel function _sf_single_pass_kernel!(
+KA.@kernel unsafe_indices=true function _sf_single_pass_kernel!(
     output_sums,                 # Matrix{FT} of size (6, N_bins-1)
     output_counts,               # Matrix{FT} of size (6, N_bins-1)
     @Const(x_mat),               # Matrix{FT} of size (2, N_points)
@@ -1187,7 +1212,7 @@ end
 # Joint 2D SF kernels (one sf_type, distance × value histogram)
 # ---------------------------------------------------------------------------
 
-KA.@kernel function _sf_joint_2d_kernel_linear!(
+KA.@kernel unsafe_indices=true function _sf_joint_2d_kernel_linear!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1227,7 +1252,7 @@ KA.@kernel function _sf_joint_2d_kernel_linear!(
     end
 end
 
-KA.@kernel function _sf_joint_2d_kernel_log!(
+KA.@kernel unsafe_indices=true function _sf_joint_2d_kernel_log!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1266,7 +1291,7 @@ KA.@kernel function _sf_joint_2d_kernel_log!(
     end
 end
 
-KA.@kernel function _sf_joint_2d_kernel!(
+KA.@kernel unsafe_indices=true function _sf_joint_2d_kernel!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1601,25 +1626,6 @@ end
 # Single-pass 2D GPU kernels (eight distance × value joint histograms)
 # ---------------------------------------------------------------------------
 
-@inline function _gpu_digitize_general_col(
-    x::T,
-    edges,
-    col::Int,
-    n_edges::Int,
-) where {T}
-    low = 1
-    high = n_edges
-    while low <= high
-        mid = (low + high) >>> 1
-        @inbounds edge_mid = edges[mid, col]
-        if edge_mid < x
-            low = mid + 1
-        else
-            high = mid - 1
-        end
-    end
-    return low - 1
-end
 
 @inline function _gpu_accumulate_single_pass_2d_pair!(
     output_sums,
@@ -1651,7 +1657,7 @@ end
     return nothing
 end
 
-KA.@kernel function _sf_single_pass_2d_kernel_linear!(
+KA.@kernel unsafe_indices=true function _sf_single_pass_2d_kernel_linear!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1685,7 +1691,7 @@ KA.@kernel function _sf_single_pass_2d_kernel_linear!(
     end
 end
 
-KA.@kernel function _sf_single_pass_2d_kernel_log!(
+KA.@kernel unsafe_indices=true function _sf_single_pass_2d_kernel_log!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -1717,7 +1723,7 @@ KA.@kernel function _sf_single_pass_2d_kernel_log!(
     end
 end
 
-KA.@kernel function _sf_single_pass_2d_kernel!(
+KA.@kernel unsafe_indices=true function _sf_single_pass_2d_kernel!(
     output_sums,
     output_counts,
     @Const(x_mat),
@@ -2012,7 +2018,7 @@ end
 
 Batch 1D structure functions over the third dimension of `x`, `u` with layout
 `(N_dims, N_points, T)`. Host outputs `sums`, `counts` have shape `(NB, T)`.
-Uploads `x`, `u` once and synchronizes the backend once after the last launch.
+Uploads `x`, `u` once and loops over optimized point-field GPU kernels.
 """
 function SFC.gpu_calculate_structure_function_slices!(
     sums::AbstractMatrix{OT},
@@ -2036,14 +2042,11 @@ function SFC.gpu_calculate_structure_function_slices!(
         throw(DimensionMismatch("counts must have shape ($NB, $T); got $(size(counts))"))
     N_dims == 2 ||
         error("GPUExt: slice batch requires N_dims=2 (got N_dims=$N_dims)")
-    sums_dev = KA.adapt(backend, zeros(FT, NB, T))
-    counts_dev = KA.adapt(backend, zeros(UInt32, NB, T))
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = false)
-    _launch_batch_varying_x_sf!(
-        backend, sums_dev, counts_dev, x_dev, u_dev, sf_type, N_points, T, lbe,
-    )
-    copy!(sums, Array(sums_dev))
-    copy!(counts, Array(counts_dev))
+    # Fused varying-x batch (B = T) through the unified N-body path (measured
+    # ~1.9× the old per-slice varying kernel; single launch, no per-slice loop).
+    oh, ch = _gpu_1d_individual_device(backend, sf_type, x, u, distance_bins, NB, T, false, OT)
+    copy!(sums, reshape(oh, NB, T))
+    copy!(counts, reshape(ch, NB, T))
     return nothing
 end
 
@@ -2073,15 +2076,12 @@ function SFC.gpu_calculate_structure_function_2d_slices!(
     size(counts) == size(sums) ||
         throw(DimensionMismatch("counts must match sums shape $(size(sums))"))
 
-    sums_dev = KA.adapt(backend, zeros(FT, n_dist, n_val, T))
-    counts_dev = KA.adapt(backend, zeros(UInt32, n_dist, n_val, T))
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = false)
-    _launch_batch_varying_x_joint2d!(
-        backend, sums_dev, counts_dev, x_dev, u_dev, sf_type, N_points, T,
-        distance_bins, value_bins, n_dist, n_val; workspace = workspace,
-    )
-    copy!(sums, Array(sums_dev))
-    copy!(counts, Array(counts_dev))
+    # Fused varying-x batch (B = T) through the unified joint-2D path (one launch,
+    # no per-slice loop; N-body + privatized histogram).
+    oh, ch = _gpu_2d_unified_device(backend, x, u, sf_type, distance_bins, value_bins,
+                                    Val(1), n_dist, n_val, T, false, OT)
+    copy!(sums, reshape(oh, n_dist, n_val, T))
+    copy!(counts, reshape(ch, n_dist, n_val, T))
     return nothing
 end
 
@@ -2111,12 +2111,11 @@ function SFC.gpu_calculate_structure_functions_single_pass_slices!(
         throw(DimensionMismatch("counts must match sums shape $(size(sums))"))
     N_dims == 2 ||
         error("GPUExt: single-pass slice batch requires N_dims=2 (got N_dims=$N_dims)")
-    sums_dev = KA.adapt(backend, zeros(FT, SF_GPU_SINGLE_PASS_N, n_bins, T))
-    counts_dev = KA.adapt(backend, zeros(UInt32, SF_GPU_SINGLE_PASS_N, n_bins, T))
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = false)
-    _launch_batch_varying_x_sp1d!(backend, sums_dev, counts_dev, x_dev, u_dev, N_points, T, lbe)
-    copy!(sums, Array(sums_dev))
-    copy!(counts, Array(counts_dev))
+    # Fused varying-x batch (B = T) through the unified N-body single-pass path.
+    oh, ch = _gpu_1d_unified_device(backend, x, u, nothing, distance_bins,
+                                    Val(SFC.SINGLE_PASS_N), n_bins, T, false, OT)
+    copy!(sums, reshape(oh, SFC.SINGLE_PASS_N, n_bins, T))
+    copy!(counts, reshape(ch, SFC.SINGLE_PASS_N, n_bins, T))
     return nothing
 end
 
@@ -2149,15 +2148,13 @@ function SFC.gpu_calculate_structure_functions_single_pass_2d_slices!(
         throw(DimensionMismatch("counts must match sums shape $(size(sums))"))
     N_dims == 2 ||
         error("GPUExt: SP2D slice batch requires N_dims=2 (got N_dims=$N_dims)")
-    val_plan = _gpu_build_value_digitize_plan(backend, value_bins)
-    sums_dev = KA.adapt(backend, zeros(FT, SF_GPU_SINGLE_PASS_N, n_bins, n_val, T))
-    counts_dev = KA.adapt(backend, zeros(UInt32, SF_GPU_SINGLE_PASS_N, n_bins, n_val, T))
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = false)
-    _launch_batch_varying_x_sp2d!(
-        backend, sums_dev, counts_dev, x_dev, u_dev, N_points, T, lbe, val_plan, n_bins, n_val,
-    )
-    copy!(sums, Array(sums_dev))
-    copy!(counts, Array(counts_dev))
+    # Fused varying-x batch (B = T) through the unified single-pass-2D path
+    # (N-body + dynamic-shared privatized histogram; ~17× the old per-slice path
+    # at 50×50, one launch instead of T).
+    oh, ch = _gpu_sp2d_unified_device(backend, x, u, distance_bins, value_bins,
+                                      n_bins, n_val, T, false, OT)
+    copy!(sums, reshape(oh, SFC.SINGLE_PASS_N, n_bins, n_val, T))
+    copy!(counts, reshape(ch, SFC.SINGLE_PASS_N, n_bins, n_val, T))
     return nothing
 end
 

--- a/ext/StructureFunctionsOhMyThreadsExt.jl
+++ b/ext/StructureFunctionsOhMyThreadsExt.jl
@@ -436,21 +436,20 @@ function SFC._dispatch_single_pass(
 
                     rh = SFH.r̂(x_i, x_j, distance_metric, r)
                     du_L = LA.dot(du, rh)
-                    du_T = SFH.mδu_t(du, rh)
-
                     du_L2 = du_L * du_L
-                    du_T2 = SFH.transverse_norm2(du, rh)
+                    du_norm2 = LA.dot(du, du)
+                    du_T2 = du_norm2 - du_L2
 
                     # Accumulate the six invariant bulk structure functions.
-                    @inbounds local_sums[1, bin_idx] += du_L2 + du_T2            # S2SF
+                    @inbounds local_sums[1, bin_idx] += du_norm2                 # S2SF
                     @inbounds local_sums[2, bin_idx] += du_L2                    # L2SF
                     @inbounds local_sums[3, bin_idx] += du_T2                    # T2SF
-                    @inbounds local_sums[4, bin_idx] += du_L * (du_L2 + du_T2)   # S3SF
-                    @inbounds local_sums[5, bin_idx] += du_L * du_L2              # L3SF
-                    @inbounds local_sums[6, bin_idx] += du_L * du_T2              # L1T2SF
+                    @inbounds local_sums[4, bin_idx] += du_L * du_norm2          # S3SF
+                    @inbounds local_sums[5, bin_idx] += du_L * du_L2             # L3SF
+                    @inbounds local_sums[6, bin_idx] += du_L * du_T2             # L1T2SF
 
-                    for t in 1:SFC.SINGLE_PASS_N
-                        @inbounds local_counts[t, bin_idx] += 1
+                    @inbounds for t in 1:SFC.SINGLE_PASS_N
+                        local_counts[t, bin_idx] += one(CT)
                     end
                 end
             end
@@ -499,20 +498,19 @@ function SFC._dispatch_single_pass!(
 
                     rh = SFH.r̂(x_i, x_j, distance_metric, r)
                     du_L = LA.dot(du, rh)
-                    du_T = SFH.mδu_t(du, rh)
-
                     du_L2 = du_L * du_L
-                    du_T2 = SFH.transverse_norm2(du, rh)
+                    du_norm2 = LA.dot(du, du)
+                    du_T2 = du_norm2 - du_L2
 
-                    @inbounds local_sums[1, bin_idx] += du_L2 + du_T2
+                    @inbounds local_sums[1, bin_idx] += du_norm2
                     @inbounds local_sums[2, bin_idx] += du_L2
                     @inbounds local_sums[3, bin_idx] += du_T2
-                    @inbounds local_sums[4, bin_idx] += du_L * (du_L2 + du_T2)
+                    @inbounds local_sums[4, bin_idx] += du_L * du_norm2
                     @inbounds local_sums[5, bin_idx] += du_L * du_L2
                     @inbounds local_sums[6, bin_idx] += du_L * du_T2
 
-                    for t in 1:SFC.SINGLE_PASS_N
-                        @inbounds local_counts[t, bin_idx] += 1
+                    @inbounds for t in 1:SFC.SINGLE_PASS_N
+                        local_counts[t, bin_idx] += one(CT)
                     end
                 end
             end
@@ -566,16 +564,15 @@ function SFC._dispatch_single_pass_2d(
 
                     rh = SFH.r̂(x_i, x_j, distance_metric, r)
                     du_L = LA.dot(du, rh)
-                    du_T = SFH.mδu_t(du, rh)
-
                     du_L2 = du_L * du_L
-                    du_T2 = SFH.transverse_norm2(du, rh)
+                    du_norm2 = LA.dot(du, du)
+                    du_T2 = du_norm2 - du_L2
 
                     vals = (
-                        du_L2 + du_T2,
+                        du_norm2,
                         du_L2,
                         du_T2,
-                        du_L * (du_L2 + du_T2),
+                        du_L * du_norm2,
                         du_L * du_L2,
                         du_L * du_T2,
                     )
@@ -638,16 +635,15 @@ function SFC._dispatch_single_pass_2d!(
 
                     rh = SFH.r̂(x_i, x_j, distance_metric, r)
                     du_L = LA.dot(du, rh)
-                    du_T = SFH.mδu_t(du, rh)
-
                     du_L2 = du_L * du_L
-                    du_T2 = SFH.transverse_norm2(du, rh)
+                    du_norm2 = LA.dot(du, du)
+                    du_T2 = du_norm2 - du_L2
 
                     vals = (
-                        du_L2 + du_T2,
+                        du_norm2,
                         du_L2,
                         du_T2,
-                        du_L * (du_L2 + du_T2),
+                        du_L * du_norm2,
                         du_L * du_L2,
                         du_L * du_T2,
                     )

--- a/ext/cuda/kernels_1d.jl
+++ b/ext/cuda/kernels_1d.jl
@@ -1,0 +1,159 @@
+# =============================================================================
+# CUDA-specialized 1D structure-function kernel (distance histogram only).
+#
+# Same N-body broadcast structure as the 2D kernel, but the histogram is tiny
+# (NMOM·NB, NB ≤ 128) so it lives in STATIC shared memory (no dynamic-shared
+# opt-in needed) and TILE = 256 (1D is geometry-bound, not occupancy-limited by
+# the histogram — measured: N-body gives the ~2× win here, replication R=1).
+# Covers individual (NMOM=1) and single-pass (NMOM=6), fixed-x and varying-x,
+# D ∈ {2,3}. Output is (NMOM, NB, B); counts are per-bin (shared across moments).
+# =============================================================================
+
+"""Compiled-in cap on distance bins for the static shared 1D histogram."""
+const CU_MAX_BINS = 128
+"""Block size for the 1D N-body kernel (settled design)."""
+const CU_TILE_1D = 256
+
+function _cuda_sf_1d_kernel!(
+    output,                 # (NMOM, NB, B)
+    counts,                 # (NMOM, NB, B)
+    x,                      # (D, N, B) varying / (D, N, 1) fixed
+    u,                      # (D, N, B)
+    sf_type,
+    ddig,                   # distance digitizer functor
+    N::Int, NB::Int,
+    nt::Int, ntb::Int,
+    ::Val{D}, ::Val{NMOM}, ::Val{FIXED_X}, ::Val{TILE},
+) where {D, NMOM, FIXED_X, TILE}
+    FT = eltype(output)
+    lid = Int(threadIdx().x)
+    wg = Int(blockDim().x)
+    lb = Int(blockIdx().x)
+    bid = (lb - 1) % ntb + 1
+    b = (lb - 1) ÷ ntb + 1
+
+    sxi = CuStaticSharedArray(FT, D * TILE)
+    sxj = CuStaticSharedArray(FT, D * TILE)
+    sui = CuStaticSharedArray(FT, D * TILE)
+    suj = CuStaticSharedArray(FT, D * TILE)
+    ssum = CuStaticSharedArray(FT, NMOM * CU_MAX_BINS)
+    scnt = CuStaticSharedArray(UInt32, CU_MAX_BINS)
+
+    c = lid
+    while c <= NMOM * NB
+        @inbounds ssum[c] = zero(FT)
+        c += wg
+    end
+    c = lid
+    while c <= NB
+        @inbounds scnt[c] = UInt32(0)
+        c += wg
+    end
+
+    ti, tj = _cuda_tile_pair(bid, nt)
+    i0 = (ti - 1) * TILE + 1
+    j0 = (tj - 1) * TILE + 1
+    ni = min(TILE, N - i0 + 1)
+    nj = min(TILE, N - j0 + 1)
+    xb = FIXED_X ? 1 : b
+
+    if lid <= ni
+        @inbounds gi = i0 + lid - 1
+        @inbounds for d in 1:D
+            sxi[(d - 1) * TILE + lid] = x[d, gi, xb]
+            sui[(d - 1) * TILE + lid] = u[d, gi, b]
+        end
+    end
+    if ti < tj && lid <= nj
+        @inbounds gj = j0 + lid - 1
+        @inbounds for d in 1:D
+            sxj[(d - 1) * TILE + lid] = x[d, gj, xb]
+            suj[(d - 1) * TILE + lid] = u[d, gj, b]
+        end
+    end
+    sync_threads()
+
+    if lid <= ni
+        Xi = _cuda_ld(sxi, Val(D), Val(TILE), lid)
+        Ui = _cuda_ld(sui, Val(D), Val(TILE), lid)
+        diag = !(ti < tj)
+        jj = diag ? lid + 1 : 1
+        jend = diag ? ni : nj
+        while jj <= jend
+            if diag
+                Xj = _cuda_ld(sxi, Val(D), Val(TILE), jj)
+                Uj = _cuda_ld(sui, Val(D), Val(TILE), jj)
+            else
+                Xj = _cuda_ld(sxj, Val(D), Val(TILE), jj)
+                Uj = _cuda_ld(suj, Val(D), Val(TILE), jj)
+            end
+            dX = Xj - Xi
+            dist = sqrt(GE._sf_dot(dX, dX))
+            bin = ddig(dist)
+            if 1 <= bin <= NB
+                rhat = dX / dist
+                moments = GE._sf_moments(Val(NMOM), sf_type, Uj - Ui, rhat)
+                @inbounds for m in 1:NMOM
+                    CUDA.@atomic ssum[(m - 1) * NB + bin] += moments[m]
+                end
+                @inbounds CUDA.@atomic scnt[bin] += UInt32(1)
+            end
+            jj += 1
+        end
+    end
+    sync_threads()
+
+    cell = lid
+    while cell <= NMOM * NB
+        @inbounds s = ssum[cell]
+        if s != zero(FT)
+            m = (cell - 1) ÷ NB + 1
+            bin = (cell - 1) % NB + 1
+            CUDA.@atomic output[m, bin, b] += s
+        end
+        cell += wg
+    end
+    bcell = lid
+    while bcell <= NB
+        @inbounds cnt = scnt[bcell]
+        if cnt != UInt32(0)
+            @inbounds for m in 1:NMOM
+                CUDA.@atomic counts[m, bcell, b] += cnt
+            end
+        end
+        bcell += wg
+    end
+    return nothing
+end
+
+
+"""Launch the CUDA 1D fast kernel. Returns `true` if launched, `false` if NB
+exceeds the static-shared cap (caller uses the KA fallback). `out`/`cnt` are
+`(NMOM, NB, B)`; `x` is `(D,N,B)` varying or `(D,N)`/`(D,N,1)` fixed; `u` is `(D,N,B)`."""
+function _cuda_launch_1d!(out, cnt, x, u, sf_type, ddig,
+                          N::Int, NB::Int, B::Int, D::Int, NMOM::Int, fixed_x::Bool)
+    NB > CU_MAX_BINS && return false
+    xv = fixed_x ? reshape(x, D, N, 1) : reshape(x, D, N, B)
+    uv = reshape(u, D, N, B)
+    _cuda_launch_1d_specialized!(out, cnt, xv, uv, sf_type, ddig, N, NB, B, D, NMOM, fixed_x)
+    return true
+end
+
+
+function _cuda_launch_1d_specialized!(out, cnt, x, u, sf_type, ddig, N, NB, B, D, NMOM, fixed_x)
+    Dv = D == 3 ? Val(3) : Val(2)
+    Mv = NMOM == 6 ? Val(6) : Val(1)
+    Fv = fixed_x ? Val(true) : Val(false)
+    _cuda_launch_1d_valed!(out, cnt, x, u, sf_type, ddig, N, NB, B, Dv, Mv, Fv, Val(CU_TILE_1D))
+    return nothing
+end
+
+function _cuda_launch_1d_valed!(out, cnt, x, u, sf_type, ddig, N, NB, B,
+                                ::Val{D}, ::Val{NMOM}, ::Val{FIXED_X}, ::Val{TILE}) where {D, NMOM, FIXED_X, TILE}
+    nt = cld(N, TILE)
+    ntb = nt * (nt + 1) ÷ 2
+    @cuda threads=TILE blocks=ntb*B _cuda_sf_1d_kernel!(
+        out, cnt, x, u, sf_type, ddig, N, NB, nt, ntb,
+        Val(D), Val(NMOM), Val(FIXED_X), Val(TILE))
+    return nothing
+end

--- a/ext/cuda/kernels_2d.jl
+++ b/ext/cuda/kernels_2d.jl
@@ -1,0 +1,216 @@
+# =============================================================================
+# CUDA-specialized 2D structure-function kernel (distance × value histogram).
+#
+# N-body broadcast structure + privatized DYNAMIC-shared histogram. This is the
+# settled-optimal design (gpu/OPTIMAL_KERNEL_DESIGN.md):
+#   - each thread owns its point i (registers); loops j over the staged tile so
+#     all lanes read the SAME shared[j] each step (broadcast, no bank conflict,
+#     no per-pair pair-decode sqrt);
+#   - per-block histogram (sums + counts) lives in dynamic shared memory (A100
+#     163 KB opt-in) and is atomic-merged to the global output at block end;
+#   - TILE = block size = 1024 (50% occupancy beats 25% on the heavy 50×50 case,
+#     measured job 238806: 8.36 vs 6.39 bapps). Device-aware: the launcher drops
+#     TILE (1024→512→256) until staging + dynamic histogram fit the device
+#     opt-in max, and returns `false` (KA fallback) if even TILE=256 won't fit.
+#
+# Covers joint 2D (NMOM=1) and single-pass 2D (NMOM=6), fixed-x and varying-x,
+# D ∈ {2,3} — all via Val type params. Validated in proto_nbody2d / proto_settle.
+# =============================================================================
+
+"""Map linear tile id `k` (1-based) to upper-triangle `(ti,tj)`, `ti ≤ tj`."""
+@inline function _cuda_tile_pair(k::Int, nt::Int)
+    ti = 1
+    rem = k
+    while rem > nt - ti + 1
+        rem -= (nt - ti + 1)
+        ti += 1
+    end
+    return ti, ti + rem - 1
+end
+
+"""Load local point `k`'s D-vector from a tile buffer staged as `(d-1)*TILE + k`."""
+@inline _cuda_ld(buf, ::Val{2}, ::Val{TILE}, k::Integer) where {TILE} =
+    @inbounds SA.SVector{2}(buf[k], buf[TILE + k])
+@inline _cuda_ld(buf, ::Val{3}, ::Val{TILE}, k::Integer) where {TILE} =
+    @inbounds SA.SVector{3}(buf[k], buf[TILE + k], buf[2 * TILE + k])
+
+function _cuda_sf_2d_kernel!(
+    output,                 # (NMOM, n_dist, n_val, B)
+    counts,                 # (NMOM, n_dist, n_val, B)
+    x,                      # (D, N, B) varying  /  (D, N, 1) fixed (reshaped by launcher)
+    u,                      # (D, N, B)
+    sf_type,
+    ddig,                   # distance digitizer functor (isbits, callable on device)
+    vplan,                  # value digitize plan (per-moment)
+    N::Int, n_dist::Int, n_val::Int,
+    nt::Int, ntb::Int,
+    ::Val{D}, ::Val{NMOM}, ::Val{FIXED_X}, ::Val{TILE}, ::Val{HCELLS},
+) where {D, NMOM, FIXED_X, TILE, HCELLS}
+    FT = eltype(output)
+    lid = Int(threadIdx().x)
+    wg = Int(blockDim().x)
+    lb = Int(blockIdx().x)
+    bid = (lb - 1) % ntb + 1
+    b = (lb - 1) ÷ ntb + 1
+
+    sxi = CuStaticSharedArray(FT, D * TILE)
+    sxj = CuStaticSharedArray(FT, D * TILE)
+    sui = CuStaticSharedArray(FT, D * TILE)
+    suj = CuStaticSharedArray(FT, D * TILE)
+    sums = CuDynamicSharedArray(FT, NMOM * HCELLS)
+    cnts = CuDynamicSharedArray(UInt32, NMOM * HCELLS, NMOM * HCELLS * sizeof(FT))
+
+    # zero the privatized histogram
+    c = lid
+    while c <= NMOM * HCELLS
+        @inbounds sums[c] = zero(FT)
+        @inbounds cnts[c] = UInt32(0)
+        c += wg
+    end
+
+    ti, tj = _cuda_tile_pair(bid, nt)
+    i0 = (ti - 1) * TILE + 1
+    j0 = (tj - 1) * TILE + 1
+    ni = min(TILE, N - i0 + 1)
+    nj = min(TILE, N - j0 + 1)
+    xb = FIXED_X ? 1 : b
+
+    # stage tile i (x for geometry, u for velocity)
+    if lid <= ni
+        @inbounds gi = i0 + lid - 1
+        @inbounds for d in 1:D
+            sxi[(d - 1) * TILE + lid] = x[d, gi, xb]
+            sui[(d - 1) * TILE + lid] = u[d, gi, b]
+        end
+    end
+    if ti < tj && lid <= nj
+        @inbounds gj = j0 + lid - 1
+        @inbounds for d in 1:D
+            sxj[(d - 1) * TILE + lid] = x[d, gj, xb]
+            suj[(d - 1) * TILE + lid] = u[d, gj, b]
+        end
+    end
+    sync_threads()
+
+    # N-body broadcast: thread owns point lid, loops j over the staged tile
+    if lid <= ni
+        Xi = _cuda_ld(sxi, Val(D), Val(TILE), lid)
+        Ui = _cuda_ld(sui, Val(D), Val(TILE), lid)
+        diag = !(ti < tj)
+        jj = diag ? lid + 1 : 1
+        jend = diag ? ni : nj
+        while jj <= jend
+            if diag
+                Xj = _cuda_ld(sxi, Val(D), Val(TILE), jj)
+                Uj = _cuda_ld(sui, Val(D), Val(TILE), jj)
+            else
+                Xj = _cuda_ld(sxj, Val(D), Val(TILE), jj)
+                Uj = _cuda_ld(suj, Val(D), Val(TILE), jj)
+            end
+            dX = Xj - Xi
+            dist = sqrt(GE._sf_dot(dX, dX))
+            dbin = ddig(dist)
+            if 1 <= dbin <= n_dist
+                rhat = dX / dist
+                moments = GE._sf_moments(Val(NMOM), sf_type, Uj - Ui, rhat)
+                @inbounds for m in 1:NMOM
+                    vb = GE._gpu_digitize_value_plan(moments[m], vplan, m, n_val + 1)
+                    if 1 <= vb <= n_val
+                        cell = (m - 1) * HCELLS + (dbin - 1) * n_val + vb
+                        CUDA.@atomic sums[cell] += moments[m]
+                        CUDA.@atomic cnts[cell] += UInt32(1)
+                    end
+                end
+            end
+            jj += 1
+        end
+    end
+    sync_threads()
+
+    # atomic-merge the privatized histogram into the global output
+    cell = lid
+    while cell <= NMOM * HCELLS
+        @inbounds s = sums[cell]
+        @inbounds cc = cnts[cell]
+        if cc != UInt32(0)
+            m = (cell - 1) ÷ HCELLS + 1
+            lc = (cell - 1) % HCELLS
+            dbin = lc ÷ n_val + 1
+            vb = lc % n_val + 1
+            CUDA.@atomic output[m, dbin, vb, b] += s
+            CUDA.@atomic counts[m, dbin, vb, b] += cc
+        end
+        cell += wg
+    end
+    return nothing
+end
+
+"""Largest TILE ∈ (1024,512,256) whose staging + dynamic histogram fit the device
+opt-in shared max; 0 if even 256 won't fit (caller falls back to the KA path)."""
+function _cuda_2d_pick_tile(::Type{FT}, D::Int, NMOM::Int, n_dist::Int, n_val::Int) where {FT}
+    optin = try
+        dev = CUDA.device()
+        Int(CUDA.attribute(dev, CUDA.DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN))
+    catch
+        48 * 1024
+    end
+    dynb = NMOM * n_dist * n_val * (sizeof(FT) + sizeof(UInt32))
+    for TILE in (1024, 512, 256)
+        staging = 4 * D * TILE * sizeof(FT)
+        if staging + dynb <= optin
+            return TILE, dynb
+        end
+    end
+    return 0, dynb
+end
+
+"""Launch the CUDA 2D fast kernel. Returns `true` if launched, `false` if the
+histogram doesn't fit any supported TILE (caller uses the KA fallback).
+`out`/`cnt` are `(NMOM, n_dist, n_val, B)`. `x` is `(D,N,B)` varying or `(D,N)`/
+`(D,N,1)` fixed; `u` is `(D,N,B)`."""
+function _cuda_launch_2d!(out, cnt, x, u, sf_type, ddig, vplan,
+                          N::Int, n_dist::Int, n_val::Int, B::Int,
+                          D::Int, NMOM::Int, fixed_x::Bool)
+    FT = eltype(out)
+    TILE, dynb = _cuda_2d_pick_tile(FT, D, NMOM, n_dist, n_val)
+    TILE == 0 && return false
+    xv = fixed_x ? reshape(x, D, N, 1) : reshape(x, D, N, B)
+    uv = reshape(u, D, N, B)
+    hcells = n_dist * n_val
+    _cuda_launch_2d_specialized!(out, cnt, xv, uv, sf_type, ddig, vplan,
+                                 N, n_dist, n_val, B, D, NMOM, fixed_x, TILE, hcells, dynb)
+    return true
+end
+
+# Resolve the runtime (D, NMOM, FIXED_X, TILE) into Val type params, then launch.
+function _cuda_launch_2d_specialized!(out, cnt, x, u, sf_type, ddig, vplan,
+                                      N, n_dist, n_val, B, D, NMOM, fixed_x, TILE, hcells, dynb)
+    Dv = D == 3 ? Val(3) : Val(2)
+    Mv = NMOM == 6 ? Val(6) : Val(1)
+    Fv = fixed_x ? Val(true) : Val(false)
+    Tv = TILE == 1024 ? Val(1024) : TILE == 512 ? Val(512) : Val(256)
+    _cuda_launch_2d_valed!(out, cnt, x, u, sf_type, ddig, vplan,
+                           N, n_dist, n_val, B, Dv, Mv, Fv, Tv, Val(hcells), dynb)
+    return nothing
+end
+
+function _cuda_launch_2d_valed!(out, cnt, x, u, sf_type, ddig, vplan,
+                                N, n_dist, n_val, B,
+                                ::Val{D}, ::Val{NMOM}, ::Val{FIXED_X}, ::Val{TILE}, ::Val{HCELLS},
+                                dynb) where {D, NMOM, FIXED_X, TILE, HCELLS}
+    nt = cld(N, TILE)
+    ntb = nt * (nt + 1) ÷ 2
+    kern = @cuda launch=false _cuda_sf_2d_kernel!(
+        out, cnt, x, u, sf_type, ddig, vplan, N, n_dist, n_val, nt, ntb,
+        Val(D), Val(NMOM), Val(FIXED_X), Val(TILE), Val(HCELLS))
+    # Opt into the larger shared budget. This must be set whenever the TOTAL
+    # (static staging + dynamic histogram) exceeds the 48 KB default cap — not
+    # only when the dynamic part alone does — so set it unconditionally. The
+    # value is the dynamic size; `_cuda_2d_pick_tile` guarantees staging + dynb
+    # ≤ the device opt-in max.
+    CUDA.attributes(kern.fun)[CUDA.FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES] = dynb
+    kern(out, cnt, x, u, sf_type, ddig, vplan, N, n_dist, n_val, nt, ntb,
+         Val(D), Val(NMOM), Val(FIXED_X), Val(TILE), Val(HCELLS);
+         threads = TILE, blocks = ntb * B, shmem = dynb)
+    return nothing
+end

--- a/ext/gpu/batch_dispatch.jl
+++ b/ext/gpu/batch_dispatch.jl
@@ -50,6 +50,67 @@ function _gpu_batch_download!(sums, counts, sums_dev, counts_dev)
     return nothing
 end
 
+"""Unified 1D batch device launch (individual `NMOM=1` or single-pass `NMOM=6`).
+Routes through `_sf_launch_1d_batch!`, taking the CUDA fast path (N-body
+broadcast + static-shared privatized histogram, TILE=256) when
+`StructureFunctionsCUDAExt` is active, else the portable KA tiled kernel. Covers
+fixed-x and varying-x, `D ∈ {2,3}`, any distance-bin type
+(`_sf_batch_dist_digitizer`). Returns host `(sums, counts)` of shape
+`(NMOM, NB, B)`. `u` is staged `(D,N,B)` with NO batch-major permute."""
+function _gpu_1d_unified_device(
+    backend, x, u, sf_type, distance_bins,
+    ::Val{NMOM}, NB::Int, B::Int, fixed_x::Bool, ::Type{OT},
+) where {NMOM, OT}
+    D = size(x, 1)
+    N = size(x, 2)
+    dig = _sf_batch_dist_digitizer(backend, distance_bins)
+    out_dev = KA.adapt(backend, zeros(OT, NMOM, NB, B))
+    cnt_dev = KA.adapt(backend, zeros(UInt32, NMOM, NB, B))
+    if fixed_x
+        x_dev = KA.adapt(backend, x)                       # (D, N)
+        u_dev = KA.adapt(backend, reshape(u, D, N, B))     # (D, N, B), no permute
+    else
+        x_dev = KA.adapt(backend, reshape(x, D, N, B))
+        u_dev = KA.adapt(backend, reshape(u, D, N, B))
+    end
+    _sf_launch_1d_batch!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, dig,
+                         N, NB, B, D, Val(NMOM), fixed_x)
+    KA.synchronize(backend)
+    return Array(out_dev), Array(cnt_dev)
+end
+
+"""Linear distance bins or `nothing` (non-throwing variant of
+`_gpu_batch_linear_distance_bins`)."""
+function _try_linear_distance_bins(distance_bins)
+    try
+        return _gpu_batch_linear_distance_bins(distance_bins)
+    catch
+        return nothing
+    end
+end
+
+"""Individual (NMOM=1) 1D batch device launch, routed to the measured-optimal
+kernel per regime (job 239164, histograms verified equal):
+- fixed-x + linear bins → OLD global warp-replica + W-strip kernel (tiny-histogram
+  contention-bound regime: 147 vs 115 bapps for N-body).
+- varying-x, or general (non-linear) fixed-x bins → N-body broadcast (115 vs 61
+  bapps for the old kernel on varying-x; also handles general bins).
+Returns host `(sums, counts)` of shape `(NB, B)`."""
+function _gpu_1d_individual_device(backend, sf_type, x, u, distance_bins,
+                                   NB::Int, B::Int, fixed_x::Bool, ::Type{OT}) where {OT}
+    lbe = fixed_x ? _try_linear_distance_bins(distance_bins) : nothing
+    if lbe !== nothing
+        N = size(x, 2)
+        sums_dev = KA.adapt(backend, zeros(OT, NB, B))
+        counts_dev = KA.adapt(backend, zeros(UInt32, NB, B))
+        x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = true)
+        _launch_batch_fixed_x_sf!(backend, sums_dev, counts_dev, x_dev, u_dev, sf_type, N, B, lbe)
+        return Array(sums_dev), Array(counts_dev)
+    end
+    oh, ch = _gpu_1d_unified_device(backend, x, u, sf_type, distance_bins, Val(1), NB, B, fixed_x, OT)
+    return reshape(oh, NB, B), reshape(ch, NB, B)
+end
+
 """
     _gpu_calculate_structure_function_batch(sf_type, backend, x, u, distance_bins, ::Val{RSAC}; ...)
 
@@ -66,23 +127,12 @@ function _gpu_calculate_structure_function_batch(
     kwargs...,
 ) where {FT, RSAC, CT}
     fixed_x = ndims(x) == 2
-    lbe = _gpu_batch_linear_distance_bins(distance_bins)
-    NB = length(lbe.edges) - 1
-    N = size(x, 2)
+    NB = length(distance_bins) - 1
     B = SFC.batch_size(u)
     bdims = SFC.batch_dims(u)
-    sums, counts = _gpu_batch_allocate_outputs(FT, NB, bdims)
-    sums_dev = KA.adapt(backend, sums)
-    counts_dev = KA.adapt(backend, counts)
-    sums_dev_flat = reshape(sums_dev, NB, B)
-    counts_dev_flat = reshape(counts_dev, NB, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
-    if fixed_x
-        _launch_batch_fixed_x_sf!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, sf_type, N, B, lbe)
-    else
-        _launch_batch_varying_x_sf!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, sf_type, N, B, lbe)
-    end
-    _gpu_batch_download!(sums, counts, sums_dev, counts_dev)
+    out_host, cnt_host = _gpu_1d_individual_device(backend, sf_type, x, u, distance_bins, NB, B, fixed_x, FT)
+    sums = reshape(out_host, NB, bdims...)
+    counts = reshape(cnt_host, NB, bdims...)
     if RSAC
         return (sums = sums, counts = CT === UInt32 ? counts : CT.(counts),
                 operator = sf_type, distance_bins = distance_bins)
@@ -107,21 +157,17 @@ function _gpu_calculate_structure_function_batch!(
     kwargs...,
 ) where {FT}
     fixed_x = ndims(x) == 2
-    lbe = _gpu_batch_linear_distance_bins(distance_bins)
-    NB = length(lbe.edges) - 1
-    N = size(x, 2)
+    NB = length(distance_bins) - 1
     B = SFC.batch_size(u)
-    sums_dev = KA.adapt(backend, zeros(eltype(output_sums), NB, SFC.batch_dims(u)...))
-    counts_dev = KA.adapt(backend, zeros(UInt32, NB, SFC.batch_dims(u)...))
-    sums_dev_flat = reshape(sums_dev, NB, B)
-    counts_dev_flat = reshape(counts_dev, NB, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
-    if fixed_x
-        _launch_batch_fixed_x_sf!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, sf_type, N, B, lbe)
+    out_host, cnt_host = _gpu_1d_individual_device(
+        backend, sf_type, x, u, distance_bins, NB, B, fixed_x, eltype(output_sums))
+    output_sums .+= reshape(out_host, size(output_sums)...)
+    cflat = reshape(cnt_host, size(output_counts)...)
+    if eltype(output_counts) === UInt32
+        output_counts .+= cflat
     else
-        _launch_batch_varying_x_sf!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, sf_type, N, B, lbe)
+        output_counts .+= eltype(output_counts).(cflat)
     end
-    _accumulate_batch_host!(output_sums, output_counts, sums_dev, counts_dev)
     return nothing
 end
 
@@ -149,24 +195,14 @@ function _gpu_dispatch_single_pass_batch(
 ) where {FT1, FT2, FT3, CT}
     FT = promote_type(float(FT1), float(FT2))
     fixed_x = ndims(x) == 2
-    lbe = _gpu_batch_linear_distance_bins(distance_bins)
-    NB = length(lbe.edges) - 1
-    N = size(x, 2)
+    NB = length(distance_bins) - 1
     B = SFC.batch_size(u)
     bdims = SFC.batch_dims(u)
-    sums, counts = _gpu_batch_allocate_sp1d(FT, NB, bdims)
-    sums_dev = KA.adapt(backend, sums)
-    counts_dev = KA.adapt(backend, counts)
-    sums_dev_flat = reshape(sums_dev, SFC.SINGLE_PASS_N, NB, B)
-    counts_dev_flat = reshape(counts_dev, SFC.SINGLE_PASS_N, NB, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
-    if fixed_x
-        _launch_batch_fixed_x_sp1d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe)
-    else
-        _launch_batch_varying_x_sp1d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe)
-    end
-    _gpu_batch_download!(sums, counts, sums_dev, counts_dev)
-    return (sums = sums, counts = CT === UInt32 ? counts : CT.(counts))
+    out_host, cnt_host = _gpu_1d_unified_device(
+        backend, x, u, nothing, distance_bins, Val(SFC.SINGLE_PASS_N), NB, B, fixed_x, FT)
+    sums = reshape(out_host, SFC.SINGLE_PASS_N, NB, bdims...)
+    counts_u32 = reshape(cnt_host, SFC.SINGLE_PASS_N, NB, bdims...)
+    return (sums = sums, counts = CT === UInt32 ? counts_u32 : CT.(counts_u32))
 end
 
 function _gpu_dispatch_single_pass_batch!(
@@ -179,29 +215,56 @@ function _gpu_dispatch_single_pass_batch!(
     kwargs...,
 ) where {OT, CT, FT1, FT2, FT3}
     fixed_x = ndims(x) == 2
-    lbe = _gpu_batch_linear_distance_bins(distance_bins)
-    N = size(x, 2)
+    NB = length(distance_bins) - 1
     B = SFC.batch_size(u)
-    sums_dev = KA.adapt(backend, zeros(OT, size(sums)...))
-    counts_dev = KA.adapt(backend, zeros(UInt32, size(counts)...))
-    sums_dev_flat = reshape(sums_dev, SFC.SINGLE_PASS_N, NB, B)
-    counts_dev_flat = reshape(counts_dev, SFC.SINGLE_PASS_N, NB, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
-    if fixed_x
-        _launch_batch_fixed_x_sp1d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe)
-    else
-        _launch_batch_varying_x_sp1d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe)
-    end
-    tmp_s = Array(sums_dev)
-    tmp_c = Array(counts_dev)
-    sums .+= tmp_s
+    out_host, cnt_host = _gpu_1d_unified_device(
+        backend, x, u, nothing, distance_bins, Val(SFC.SINGLE_PASS_N), NB, B, fixed_x, OT)
+    sums .+= reshape(out_host, size(sums)...)
+    cflat = reshape(cnt_host, size(counts)...)
     if CT === UInt32
-        counts .+= tmp_c
+        counts .+= cflat
     else
-        counts .+= CT.(tmp_c)
+        counts .+= CT.(cflat)
     end
     return sums, counts
 end
+
+"""Unified single-pass 2D batch device launch. Routes through the same
+`_sf_launch_2d_batch!` chokepoint as joint 2D, so it takes the CUDA fast path
+(N-body broadcast + dynamic-shared privatized histogram, TILE=1024) when
+`StructureFunctionsCUDAExt` is active, and the portable KA tiled kernel
+otherwise. Covers fixed-x and varying-x, `D ∈ {2,3}`, and any distance-bin type
+(`_sf_batch_dist_digitizer`). Returns host `(sums, counts)` of shape
+`(6, n_dist, n_val, B)`. `u` is staged `(D,N,B)` with NO batch-major permute (the
+unified kernels read `u[d, point, b]` directly)."""
+function _gpu_2d_unified_device(
+    backend, x, u, sf_type, distance_bins, value_bins, ::Val{NMOM},
+    n_dist::Int, n_val::Int, B::Int, fixed_x::Bool, ::Type{OT},
+) where {NMOM, OT}
+    D = size(x, 1)
+    N = size(x, 2)
+    ddig = _sf_batch_dist_digitizer(backend, distance_bins)
+    vplan = _gpu_build_value_digitize_plan(backend, value_bins)
+    out_dev = KA.adapt(backend, zeros(OT, NMOM, n_dist, n_val, B))
+    cnt_dev = KA.adapt(backend, zeros(UInt32, NMOM, n_dist, n_val, B))
+    if fixed_x
+        x_dev = KA.adapt(backend, x)                       # (D, N)
+        u_dev = KA.adapt(backend, reshape(u, D, N, B))     # (D, N, B), no permute
+    else
+        x_dev = KA.adapt(backend, reshape(x, D, N, B))
+        u_dev = KA.adapt(backend, reshape(u, D, N, B))
+    end
+    _sf_launch_2d_batch!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, ddig, vplan,
+                         N, n_dist, n_val, B, D, Val(NMOM), fixed_x)
+    KA.synchronize(backend)
+    return Array(out_dev), Array(cnt_dev)
+end
+
+"""Single-pass (NMOM=6) 2D batch device launch — thin wrapper over the unified
+`_gpu_2d_unified_device`."""
+_gpu_sp2d_unified_device(backend, x, u, distance_bins, value_bins, n_dist, n_val, B, fixed_x, ::Type{OT}) where {OT} =
+    _gpu_2d_unified_device(backend, x, u, nothing, distance_bins, value_bins,
+                           Val(SFC.SINGLE_PASS_N), n_dist, n_val, B, fixed_x, OT)
 
 function _gpu_dispatch_single_pass_2d_batch(
     backend::KA.Backend,
@@ -214,27 +277,16 @@ function _gpu_dispatch_single_pass_2d_batch(
 ) where {FT1, FT2, FT3, CT}
     FT = promote_type(float(FT1), float(FT2))
     fixed_x = ndims(x) == 2
-    lbe = _gpu_batch_linear_distance_bins(distance_bins)
     n_dist = length(distance_bins) - 1
     n_val = _sp2d_n_val_edges(value_bins) - 1
     SFC._validate_value_bins!(value_bins, n_val)
-    val_plan = _gpu_build_value_digitize_plan(backend, value_bins)
-    N = size(x, 2)
     B = SFC.batch_size(u)
     bdims = SFC.batch_dims(u)
-    sums, counts = _gpu_batch_allocate_sp2d(FT, n_dist, n_val, bdims)
-    sums_dev = KA.adapt(backend, sums)
-    counts_dev = KA.adapt(backend, counts)
-    sums_dev_flat = reshape(sums_dev, SFC.SINGLE_PASS_N, n_dist, n_val, B)
-    counts_dev_flat = reshape(counts_dev, SFC.SINGLE_PASS_N, n_dist, n_val, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
-    if fixed_x
-        _launch_batch_fixed_x_sp2d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe, val_plan, n_dist, n_val)
-    else
-        _launch_batch_varying_x_sp2d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe, val_plan, n_dist, n_val)
-    end
-    _gpu_batch_download!(sums, counts, sums_dev, counts_dev)
-    return (sums = sums, counts = CT === UInt32 ? counts : CT.(counts))
+    out_host, cnt_host = _gpu_sp2d_unified_device(
+        backend, x, u, distance_bins, value_bins, n_dist, n_val, B, fixed_x, FT)
+    sums = reshape(out_host, SFC.SINGLE_PASS_N, n_dist, n_val, bdims...)
+    counts_u32 = reshape(cnt_host, SFC.SINGLE_PASS_N, n_dist, n_val, bdims...)
+    return (sums = sums, counts = CT === UInt32 ? counts_u32 : CT.(counts_u32))
 end
 
 function _gpu_dispatch_single_pass_2d_batch!(
@@ -248,29 +300,16 @@ function _gpu_dispatch_single_pass_2d_batch!(
     kwargs...,
 ) where {OT, CT, FT1, FT2, FT3}
     fixed_x = ndims(x) == 2
-    lbe = _gpu_batch_linear_distance_bins(distance_bins)
     n_dist = length(distance_bins) - 1
     n_val = size(sums, 3)
-    val_plan = _gpu_build_value_digitize_plan(backend, value_bins)
-    N = size(x, 2)
     B = SFC.batch_size(u)
-    sums_dev = KA.adapt(backend, zeros(OT, size(sums)...))
-    counts_dev = KA.adapt(backend, zeros(UInt32, size(counts)...))
-    sums_dev_flat = reshape(sums_dev, SFC.SINGLE_PASS_N, n_dist, n_val, B)
-    counts_dev_flat = reshape(counts_dev, SFC.SINGLE_PASS_N, n_dist, n_val, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
-    if fixed_x
-        _launch_batch_fixed_x_sp2d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe, val_plan, n_dist, n_val)
-    else
-        _launch_batch_varying_x_sp2d!(backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, N, B, lbe, val_plan, n_dist, n_val)
-    end
-    tmp_s = Array(sums_dev)
-    tmp_c = Array(counts_dev)
-    sums .+= tmp_s
+    out_host, cnt_host = _gpu_sp2d_unified_device(
+        backend, x, u, distance_bins, value_bins, n_dist, n_val, B, fixed_x, OT)
+    sums .+= reshape(out_host, size(sums)...)
     if CT === UInt32
-        counts .+= tmp_c
+        counts .+= reshape(cnt_host, size(counts)...)
     else
-        counts .+= CT.(tmp_c)
+        counts .+= CT.(reshape(cnt_host, size(counts)...))
     end
     return sums, counts
 end
@@ -281,7 +320,11 @@ function _gpu_batch_allocate_joint2d(FT::Type, n_dist::Int, n_val::Int, bdims::D
     return sums, counts
 end
 
-"""Fused GPU batch driver for single-type joint 2D structure functions."""
+"""Fused GPU batch driver for single-type joint 2D structure functions.
+
+Unified path: one fused tiled launch (`sf_tiled_2d_*`) per fixed/varying mode —
+no host `for b` loop, no naive per-cell kernel, no per-iteration allocations.
+This is the path that fixes the prior batch joint2d performance regression."""
 function _gpu_calculate_structure_function_2d_batch(
     sf_type::SFT.AbstractPairwiseStructureFunctionType,
     backend::KA.Backend,
@@ -295,28 +338,30 @@ function _gpu_calculate_structure_function_2d_batch(
     fixed_x = ndims(x) == 2
     n_dist = length(distance_bins) - 1
     n_val = length(value_bins) - 1
+    D = size(x, 1)
     N = size(x, 2)
     B = SFC.batch_size(u)
     bdims = SFC.batch_dims(u)
-    sums, counts = _gpu_batch_allocate_joint2d(FT, n_dist, n_val, bdims)
-    sums_dev = KA.adapt(backend, sums)
-    counts_dev = KA.adapt(backend, counts)
-    sums_dev_flat = reshape(sums_dev, n_dist, n_val, B)
-    counts_dev_flat = reshape(counts_dev, n_dist, n_val, B)
-    x_dev, u_dev = _stage_batch_device(backend, x, u; fixed_x = fixed_x)
+
+    ddig = _sf_batch_dist_digitizer(backend, distance_bins)
+    vplan = _gpu_build_value_digitize_plan(backend, value_bins)
+
+    out_dev = KA.adapt(backend, zeros(FT, 1, n_dist, n_val, B))
+    cnt_dev = KA.adapt(backend, zeros(UInt32, 1, n_dist, n_val, B))
+
     if fixed_x
-        _launch_batch_fixed_x_joint2d!(
-            backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, sf_type, N, B,
-            distance_bins, value_bins, n_dist, n_val,
-        )
+        x_dev = KA.adapt(backend, x)                       # (D, N)
+        u_dev = KA.adapt(backend, reshape(u, D, N, B))     # (D, N, B) — no permute
     else
-        _launch_batch_varying_x_joint2d!(
-            backend, sums_dev_flat, counts_dev_flat, x_dev, u_dev, sf_type, N, B,
-            distance_bins, value_bins, n_dist, n_val,
-        )
+        x_dev = KA.adapt(backend, reshape(x, D, N, B))
+        u_dev = KA.adapt(backend, reshape(u, D, N, B))
     end
-    _gpu_batch_download!(sums, counts, sums_dev, counts_dev)
-    return SF.StructureFunction2D(
-        sf_type, distance_bins, value_bins, sums, CT === UInt32 ? counts : CT.(counts),
-    )
+    _sf_launch_2d_batch!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, ddig, vplan,
+                         N, n_dist, n_val, B, D, Val(1), fixed_x)
+    KA.synchronize(backend)
+
+    sums = reshape(Array(out_dev)[1, :, :, :], n_dist, n_val, bdims...)
+    counts_u32 = reshape(Array(cnt_dev)[1, :, :, :], n_dist, n_val, bdims...)
+    counts = CT === UInt32 ? counts_u32 : CT.(counts_u32)
+    return SF.StructureFunction2D(sf_type, distance_bins, value_bins, sums, counts)
 end

--- a/ext/gpu/kernels_1d.jl
+++ b/ext/gpu/kernels_1d.jl
@@ -9,7 +9,7 @@
 
 # Shared layout: SF_GPU_TILE=128 → 2D shared coords length 256, 3D length 384.
 
-KA.@kernel function _sf_kernel_tiled128_2d_linear_u32!(
+KA.@kernel unsafe_indices=true function _sf_kernel_tiled128_2d_linear_u32!(
     output,
     counts,
     x_mat,
@@ -34,20 +34,16 @@ KA.@kernel function _sf_kernel_tiled128_2d_linear_u32!(
     shared_uj = @localmem FT (256,)
     shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for b in 1:NB
-            shared_sums[b] = zero(FT)
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -82,10 +78,8 @@ KA.@kernel function _sf_kernel_tiled128_2d_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -127,10 +121,8 @@ KA.@kernel function _sf_kernel_tiled128_2d_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         b = lid
         while b <= NB
@@ -143,7 +135,7 @@ KA.@kernel function _sf_kernel_tiled128_2d_linear_u32!(
     end
 end
 
-KA.@kernel function _sf_kernel_tiled128_3d_linear_u32!(
+KA.@kernel unsafe_indices=true function _sf_kernel_tiled128_3d_linear_u32!(
     output,
     counts,
     x_mat,
@@ -168,20 +160,16 @@ KA.@kernel function _sf_kernel_tiled128_3d_linear_u32!(
     shared_uj = @localmem FT (384,)
     shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for b in 1:NB
-            shared_sums[b] = zero(FT)
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -220,10 +208,8 @@ KA.@kernel function _sf_kernel_tiled128_3d_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -265,10 +251,8 @@ KA.@kernel function _sf_kernel_tiled128_3d_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         b = lid
         while b <= NB
@@ -281,7 +265,7 @@ KA.@kernel function _sf_kernel_tiled128_3d_linear_u32!(
     end
 end
 
-KA.@kernel function _sf_kernel_tiled128_2d_log_u32!(
+KA.@kernel unsafe_indices=true function _sf_kernel_tiled128_2d_log_u32!(
     output,
     counts,
     x_mat,
@@ -306,20 +290,16 @@ KA.@kernel function _sf_kernel_tiled128_2d_log_u32!(
     shared_uj = @localmem FT (256,)
     shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for b in 1:NB
-            shared_sums[b] = zero(FT)
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -354,10 +334,8 @@ KA.@kernel function _sf_kernel_tiled128_2d_log_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -397,10 +375,8 @@ KA.@kernel function _sf_kernel_tiled128_2d_log_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         b = lid
         while b <= NB
@@ -413,7 +389,7 @@ KA.@kernel function _sf_kernel_tiled128_2d_log_u32!(
     end
 end
 
-KA.@kernel function _sf_kernel_tiled128_3d_log_u32!(
+KA.@kernel unsafe_indices=true function _sf_kernel_tiled128_3d_log_u32!(
     output,
     counts,
     x_mat,
@@ -438,20 +414,16 @@ KA.@kernel function _sf_kernel_tiled128_3d_log_u32!(
     shared_uj = @localmem FT (384,)
     shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for b in 1:NB
-            shared_sums[b] = zero(FT)
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -490,10 +462,8 @@ KA.@kernel function _sf_kernel_tiled128_3d_log_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -533,10 +503,8 @@ KA.@kernel function _sf_kernel_tiled128_3d_log_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         b = lid
         while b <= NB
@@ -549,7 +517,7 @@ KA.@kernel function _sf_kernel_tiled128_3d_log_u32!(
     end
 end
 
-KA.@kernel function _sf_kernel_tiled128_2d_general_u32!(
+KA.@kernel unsafe_indices=true function _sf_kernel_tiled128_2d_general_u32!(
     output,
     counts,
     x_mat,
@@ -571,20 +539,16 @@ KA.@kernel function _sf_kernel_tiled128_2d_general_u32!(
     shared_uj = @localmem FT (256,)
     shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for b in 1:NB
-            shared_sums[b] = zero(FT)
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -619,10 +583,8 @@ KA.@kernel function _sf_kernel_tiled128_2d_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -662,10 +624,8 @@ KA.@kernel function _sf_kernel_tiled128_2d_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         b = lid
         while b <= NB
@@ -678,7 +638,7 @@ KA.@kernel function _sf_kernel_tiled128_2d_general_u32!(
     end
 end
 
-KA.@kernel function _sf_kernel_tiled128_3d_general_u32!(
+KA.@kernel unsafe_indices=true function _sf_kernel_tiled128_3d_general_u32!(
     output,
     counts,
     x_mat,
@@ -700,20 +660,16 @@ KA.@kernel function _sf_kernel_tiled128_3d_general_u32!(
     shared_uj = @localmem FT (384,)
     shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for b in 1:NB
-            shared_sums[b] = zero(FT)
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -752,10 +708,8 @@ KA.@kernel function _sf_kernel_tiled128_3d_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -795,10 +749,8 @@ KA.@kernel function _sf_kernel_tiled128_3d_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         b = lid
         while b <= NB

--- a/ext/gpu/kernels_1d_single_pass.jl
+++ b/ext/gpu/kernels_1d_single_pass.jl
@@ -1,28 +1,29 @@
 # Tiled128 six-invariant-type single-pass 1D distance histogram kernels (linear/log/general).
 # Included from StructureFunctionsGPUExt.jl — block-local (6, NB) sums + one count row.
 
-"""Accumulate six invariant native 1D SF types into flat `@localmem` sums `(6*NB,)`."""
+"""Accumulate six invariant native 1D SF types into flat `@localmem` sums `(6*NB,)`.
+du_norm2 = du_L2 + du_T2 (= ||dU||²) must be pre-computed by the caller."""
 @inline function _gpu_accumulate_single_pass_1d_shared!(
     shared_sums,
     shared_cnts,
     bin::Int,
     du_L,
-    du_T,
     du_L2,
     du_T2,
+    du_norm2,
     NB::Int,
 )
-    @atomic shared_sums[bin] += du_L2 + du_T2
+    @atomic shared_sums[bin] += du_norm2
     @atomic shared_sums[NB + bin] += du_L2
     @atomic shared_sums[2NB + bin] += du_T2
-    @atomic shared_sums[3NB + bin] += du_L * (du_L2 + du_T2)
+    @atomic shared_sums[3NB + bin] += du_L * du_norm2
     @atomic shared_sums[4NB + bin] += du_L * du_L2
     @atomic shared_sums[5NB + bin] += du_L * du_T2
     @atomic shared_cnts[bin] += UInt32(1)
     return nothing
 end
 
-KA.@kernel function _sf6_single_pass_kernel_tiled128_linear_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_kernel_tiled128_linear_u32!(
     output_sums,
     output_counts,
     x_mat,
@@ -45,22 +46,20 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_linear_u32!(
     shared_uj = @localmem FT (256,)
     shared_sums = @localmem FT (SF_GPU_SINGLE_PASS_N * SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for k in 1:(SF_GPU_SINGLE_PASS_N * NB)
-            shared_sums[k] = zero(FT)
-        end
-        @inbounds for b in 1:NB
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    k_init = lid
+    while k_init <= SF_GPU_SINGLE_PASS_N * NB
+        @inbounds shared_sums[k_init] = zero(FT)
+        k_init += workgroup_size
+    end
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -95,10 +94,8 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -131,13 +128,12 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_linear_u32!(
                 if 1 <= bin < N_bins
                     dU = U2 - U1
                     r̂ = dX / dist
-                    n̂ = SA.SVector{2, FT}(r̂[2], -r̂[1])
                     du_L = SA.dot(dU, r̂)
-                    du_T = SA.dot(dU, n̂)
                     du_L2 = du_L * du_L
-                    du_T2 = du_T * du_T
+                    du_norm2 = SA.dot(dU, dU)
+                    du_T2 = du_norm2 - du_L2
                     _gpu_accumulate_single_pass_1d_shared!(
-                        shared_sums, shared_cnts, bin, du_L, du_T, du_L2, du_T2, NB,
+                        shared_sums, shared_cnts, bin, du_L, du_L2, du_T2, du_norm2, NB,
                     )
                 end
                 p += workgroup_size
@@ -145,10 +141,8 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         k = lid
         while k <= SF_GPU_SINGLE_PASS_N * NB
@@ -173,7 +167,7 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_linear_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_kernel_tiled128_log_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_kernel_tiled128_log_u32!(
     output_sums,
     output_counts,
     x_mat,
@@ -196,22 +190,20 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_log_u32!(
     shared_uj = @localmem FT (256,)
     shared_sums = @localmem FT (SF_GPU_SINGLE_PASS_N * SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for k in 1:(SF_GPU_SINGLE_PASS_N * NB)
-            shared_sums[k] = zero(FT)
-        end
-        @inbounds for b in 1:NB
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    k_init = lid
+    while k_init <= SF_GPU_SINGLE_PASS_N * NB
+        @inbounds shared_sums[k_init] = zero(FT)
+        k_init += workgroup_size
+    end
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -246,10 +238,8 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_log_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -280,13 +270,12 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_log_u32!(
                 if 1 <= bin < N_bins
                     dU = U2 - U1
                     r̂ = dX / dist
-                    n̂ = SA.SVector{2, FT}(r̂[2], -r̂[1])
                     du_L = SA.dot(dU, r̂)
-                    du_T = SA.dot(dU, n̂)
                     du_L2 = du_L * du_L
-                    du_T2 = du_T * du_T
+                    du_norm2 = SA.dot(dU, dU)
+                    du_T2 = du_norm2 - du_L2
                     _gpu_accumulate_single_pass_1d_shared!(
-                        shared_sums, shared_cnts, bin, du_L, du_T, du_L2, du_T2, NB,
+                        shared_sums, shared_cnts, bin, du_L, du_L2, du_T2, du_norm2, NB,
                     )
                 end
                 p += workgroup_size
@@ -294,10 +283,8 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_log_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         k = lid
         while k <= SF_GPU_SINGLE_PASS_N * NB
@@ -322,7 +309,7 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_log_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_kernel_tiled128_general_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_kernel_tiled128_general_u32!(
     output_sums,
     output_counts,
     x_mat,
@@ -342,22 +329,20 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_general_u32!(
     shared_uj = @localmem FT (256,)
     shared_sums = @localmem FT (SF_GPU_SINGLE_PASS_N * SF_GPU_MAX_BINS,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    if lid == 1
-        @inbounds for k in 1:(SF_GPU_SINGLE_PASS_N * NB)
-            shared_sums[k] = zero(FT)
-        end
-        @inbounds for b in 1:NB
-            shared_cnts[b] = UInt32(0)
-        end
+    lid = @index(Local, Linear)
+    k_init = lid
+    while k_init <= SF_GPU_SINGLE_PASS_N * NB
+        @inbounds shared_sums[k_init] = zero(FT)
+        k_init += workgroup_size
+    end
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -392,10 +377,8 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -426,13 +409,12 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_general_u32!(
                 if 1 <= bin < N_bins
                     dU = U2 - U1
                     r̂ = dX / dist
-                    n̂ = SA.SVector{2, FT}(r̂[2], -r̂[1])
                     du_L = SA.dot(dU, r̂)
-                    du_T = SA.dot(dU, n̂)
                     du_L2 = du_L * du_L
-                    du_T2 = du_T * du_T
+                    du_norm2 = SA.dot(dU, dU)
+                    du_T2 = du_norm2 - du_L2
                     _gpu_accumulate_single_pass_1d_shared!(
-                        shared_sums, shared_cnts, bin, du_L, du_T, du_L2, du_T2, NB,
+                        shared_sums, shared_cnts, bin, du_L, du_L2, du_T2, du_norm2, NB,
                     )
                 end
                 p += workgroup_size
@@ -440,10 +422,8 @@ KA.@kernel function _sf6_single_pass_kernel_tiled128_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         k = lid
         while k <= SF_GPU_SINGLE_PASS_N * NB

--- a/ext/gpu/kernels_2d.jl
+++ b/ext/gpu/kernels_2d.jl
@@ -22,8 +22,7 @@ end
 """Cooperative grid-stride zero of block-local joint histogram (uses runtime `NB2`)."""
 function _joint2d_cooperative_zero_body()
     return quote
-        g = @index(Global, Linear)
-        lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
         b = lid
         while b <= NB2
             @inbounds begin
@@ -125,7 +124,7 @@ function _joint2d_kernel_def(dist_route::Symbol, val_route::Symbol, compile_cell
     val_digitize = _joint2d_val_digitize_expr(val_route)
     params = _joint2d_kernel_param_exprs(dist_route, val_route)
     return quote
-        KA.@kernel function $(fname)($(params...),) where {FT}
+        KA.@kernel unsafe_indices=true function $(fname)($(params...),) where {FT}
             shared_xi = @localmem FT (256,)
             shared_ui = @localmem FT (256,)
             shared_xj = @localmem FT (256,)
@@ -134,10 +133,8 @@ function _joint2d_kernel_def(dist_route::Symbol, val_route::Symbol, compile_cell
             shared_cnts = @localmem UInt32 ($(hist),)
 
             $(zero_body)
-
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
-            bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
             if bid <= n_tile_blocks
                 ti, tj = _tile_from_linear(bid, n_tiles)
                 i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -172,10 +169,8 @@ function _joint2d_kernel_def(dist_route::Symbol, val_route::Symbol, compile_cell
                 end
             end
             @synchronize
-
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
-            bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
             if bid <= n_tile_blocks
                 ti, tj = _tile_from_linear(bid, n_tiles)
                 i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -218,10 +213,8 @@ function _joint2d_kernel_def(dist_route::Symbol, val_route::Symbol, compile_cell
                 end
             end
             @synchronize
-
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
-            bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
             if bid <= n_tile_blocks
                 b = lid
                 while b <= NB2

--- a/ext/gpu/kernels_2d_direct.jl
+++ b/ext/gpu/kernels_2d_direct.jl
@@ -7,11 +7,11 @@
 # See gpu/SP2D_HTP_EJ.md for strategy, benchmarks, and future perf notes.
 # Included from StructureFunctionsGPUExt.jl after TiledSinglePass2DValueKernels.jl.
 
-@inline function _sp2d_flat_index(t::Int, dbin::Int, vbin::Int, n_dist::Int, n_val::Int)
+@inline function _sp2d_flat_index(t, dbin, vbin, n_dist, n_val)
     return (t - 1) * n_dist * n_val + (dbin - 1) * n_val + vbin
 end
 
-@inline function _sp2d_decode_flat_index(g::Int, n_dist::Int, n_val::Int)
+@inline function _sp2d_decode_flat_index(g, n_dist, n_val)
     t = (g - 1) ÷ (n_dist * n_val) + 1
     rem = (g - 1) % (n_dist * n_val)
     dbin = rem ÷ n_val + 1
@@ -25,9 +25,9 @@ end
     C::Int,
     lid::Int,
     workgroup_size::Int,
-    ::Type{FT},
-) where {FT}
+)
     g = lid
+    FT = eltype(shared_sums)
     while g <= C
         @inbounds begin
             shared_sums[g] = zero(FT)
@@ -44,12 +44,12 @@ end
     partition_counts,
     shared_sums,
     shared_cnts,
-    C::Int,
-    n_dist::Int,
-    n_val::Int,
-    block_id::Int,
-    lid::Int,
-    workgroup_size::Int,
+    C,
+    n_dist,
+    n_val,
+    block_id,
+    lid,
+    workgroup_size,
 )
     g = lid
     while g <= C
@@ -71,11 +71,11 @@ end
     out_cnts,
     shared_sums,
     shared_cnts,
-    C::Int,
-    n_dist::Int,
-    n_val::Int,
-    lid::Int,
-    workgroup_size::Int,
+    C,
+    n_dist,
+    n_val,
+    lid,
+    workgroup_size,
 )
     g = lid
     while g <= C
@@ -95,7 +95,7 @@ end
 
 @inline function _gpu_accumulate_sp2d_sharedhist_linear_val!(
     shared_sums, shared_cnts, n_dist, n_val,
-    dbin::Int, du_L, du_T, du_L2, du_T2, N_val_edges::Int,
+    dbin, du_L, du_T, du_L2, du_T2, N_val_edges,
     val_first::FT, val_last::FT, val_inv_step::FT, val_offset::FT, val_step::FT,
 ) where {FT}
     vals = SA.SVector(
@@ -677,7 +677,7 @@ end
 
 # --- merge: serial (per-cell loop over blocks) and parallel (workgroup tree-reduce) ---
 
-KA.@kernel function _merge_sp2d_partitions_serial_u32!(
+KA.@kernel unsafe_indices=true function _merge_sp2d_partitions_serial_u32!(
     output_sums,
     output_counts,
     partition_sums,
@@ -705,7 +705,7 @@ KA.@kernel function _merge_sp2d_partitions_serial_u32!(
 end
 
 """Parallel merge: one workgroup per joint cell (`ndrange = C × workgroup_size`)."""
-KA.@kernel function _merge_sp2d_partitions_parallel_u32!(
+KA.@kernel unsafe_indices=true function _merge_sp2d_partitions_parallel_u32!(
     output_sums::AbstractArray{FT, 3},
     output_counts::AbstractArray{UInt32, 3},
     partition_sums::AbstractArray{FT, 4},
@@ -1139,14 +1139,12 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
     accum_body = if accum_mode == :typeplane
         quote
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if lid == 1
                 @inbounds shared_type_pass[1] = 1
             end
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if @inbounds(shared_block_id[1]) <= n_tile_blocks &&
                @inbounds(shared_tile[3]) > 0 && @inbounds(shared_tile[4]) > 0
                 block_id = @inbounds(shared_block_id[1])
@@ -1156,15 +1154,19 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
                 @inbounds nj = shared_tile[4]
                 n_pairs = ti < tj ? ni * nj : ni * (ni - 1) ÷ 2
                 for _ in 1:n_type_passes
-                    g = @index(Global, Linear)
-                    lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
                     @inbounds type_pass = shared_type_pass[1]
-                    _sp2d_zero_shared_hist!(
-                        shared_sums, shared_cnts, types_per_pass * plane, lid, workgroup_size, FT,
-                    )
+                    let g_zero = lid
+                        while g_zero <= types_per_pass * plane
+                            @inbounds begin
+                                shared_sums[g_zero] = zero(FT)
+                                shared_cnts[g_zero] = zero(UInt32)
+                            end
+                            g_zero += workgroup_size
+                        end
+                    end
                     @synchronize
-                    g = @index(Global, Linear)
-                    lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
                     block_id = @inbounds(shared_block_id[1])
                     @inbounds ti = shared_tile[1]
                     @inbounds tj = shared_tile[2]
@@ -1174,8 +1176,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
                     n_pairs = ti < tj ? ni * nj : ni * (ni - 1) ÷ 2
                     $(pair_loop)
                     @synchronize
-                    g = @index(Global, Linear)
-                    lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
                     @inbounds type_pass = shared_type_pass[1]
                     block_id = @inbounds(shared_block_id[1])
                     _sp2d_flush_typeplane_to_output!(
@@ -1183,8 +1184,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
                         NB, N_val_edges - 1, lid, workgroup_size,
                     )
                     @synchronize
-                    g = @index(Global, Linear)
-                    lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
                     if lid == 1
                         @inbounds shared_type_pass[1] += 1
                     end
@@ -1195,14 +1195,20 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
     elseif accum_mode == :shared
         quote
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if @inbounds(shared_block_id[1]) <= n_tile_blocks
-                _sp2d_zero_shared_hist!(shared_sums, shared_cnts, C, lid, workgroup_size, FT)
+                let g_zero = lid
+                    while g_zero <= C
+                        @inbounds begin
+                            shared_sums[g_zero] = zero(FT)
+                            shared_cnts[g_zero] = zero(UInt32)
+                        end
+                        g_zero += workgroup_size
+                    end
+                end
             end
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if @inbounds(shared_block_id[1]) <= n_tile_blocks &&
                @inbounds(shared_tile[3]) > 0 && @inbounds(shared_tile[4]) > 0
                 block_id = @inbounds(shared_block_id[1])
@@ -1214,8 +1220,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
                 $(pair_loop)
             end
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             _sp2d_flush_shared_to_output!(
                 out_sums, out_cnts, shared_sums, shared_cnts, C, NB, N_val_edges - 1,
                 lid, workgroup_size,
@@ -1224,8 +1229,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
     else
         quote
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if @inbounds(shared_block_id[1]) <= n_tile_blocks &&
                @inbounds(shared_tile[3]) > 0 && @inbounds(shared_tile[4]) > 0
                 block_id = @inbounds(shared_block_id[1])
@@ -1242,7 +1246,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
         [:(partition_sums), :(partition_counts)] :
         [:(out_sums), :(out_cnts)]
     return quote
-        KA.@kernel function $(fname)(
+        KA.@kernel unsafe_indices=true function $(fname)(
             $(hist_params...), x_mat, u_mat,
             N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
             $(dist_params...),
@@ -1263,8 +1267,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
                 @inbounds shared_block_id[1] = (g - 1) ÷ workgroup_size + 1
             end
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if @inbounds(shared_block_id[1]) <= n_tile_blocks
                 ti, tj = _tile_from_linear(@inbounds(shared_block_id[1]), n_tiles)
                 i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -1277,8 +1280,7 @@ function _sp2d_partition_kernel_def(accum_mode::Symbol, dist::Symbol, val::Symbo
                 )
             end
             @synchronize
-            g = @index(Global, Linear)
-            lid = (g - 1) % workgroup_size + 1
+    lid = @index(Local, Linear)
             if @inbounds(shared_block_id[1]) <= n_tile_blocks
                 ti, tj = _tile_from_linear(@inbounds(shared_block_id[1]), n_tiles)
                 i0 = (ti - 1) * SF_GPU_TILE + 1

--- a/ext/gpu/kernels_2d_single_pass.jl
+++ b/ext/gpu/kernels_2d_single_pass.jl
@@ -245,7 +245,7 @@ end
     return nothing
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_linear_linear_u32!(
     output_sums,
     output_counts,
     x_mat,
@@ -272,10 +272,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -310,10 +308,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -363,7 +359,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_general_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_general_u32!(
     output_sums,
     output_counts,
     x_mat,
@@ -386,10 +382,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_general_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -424,10 +418,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_general_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -474,7 +466,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_general_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_u32!(
     output_sums,
     output_counts,
     x_mat,
@@ -501,10 +493,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -539,10 +529,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_u32!(
         end
     end
     @synchronize
-
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1

--- a/ext/gpu/kernels_2d_value_axis.jl
+++ b/ext/gpu/kernels_2d_value_axis.jl
@@ -31,7 +31,7 @@ function _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_ma
     return nothing
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_val_cols_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_linear_linear_val_cols_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -42,9 +42,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_val_cols_u
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -54,9 +53,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_val_cols_u
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -103,7 +101,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_linear_val_cols_u
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_cols_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_cols_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -114,9 +112,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_cols_u32!
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -126,9 +123,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_cols_u32!
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -175,7 +171,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_linear_val_cols_u32!
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -187,9 +183,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_u32
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -199,9 +194,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_u32
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -248,7 +242,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_u32
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -260,9 +254,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -272,9 +265,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_u32!(
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -321,7 +313,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_cols_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_cols_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -333,9 +325,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_col
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -345,9 +336,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_col
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -394,7 +384,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_inflinear_val_col
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_cols_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_cols_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -406,9 +396,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_cols_u
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -418,9 +407,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_cols_u
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -467,7 +455,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_inflinear_val_cols_u
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_log_val_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -478,9 +466,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -490,9 +477,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_u32!(
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -539,7 +525,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_vector_val_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_vector_val_u32!(
     output_sums, output_counts, x_mat, u_mat,
     @Const(value_edges),
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
@@ -550,9 +536,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_vector_val_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -562,9 +547,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_vector_val_u32!(
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -611,7 +595,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_vector_val_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -622,9 +606,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -634,9 +617,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_u32!(
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -683,7 +665,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_u32!(
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_cols_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_cols_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -694,9 +676,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_cols_u32!
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -706,9 +687,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_cols_u32!
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -755,7 +735,7 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_linear_log_val_cols_u32!
     end
 end
 
-KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_cols_u32!(
+KA.@kernel unsafe_indices=true function _sf6_single_pass_2d_kernel_tiled128_log_log_val_cols_u32!(
     output_sums, output_counts, x_mat, u_mat,
     N_points::Int, N_bins::Int, NB::Int, N_val_edges::Int,
     dist_first::FT, dist_last::FT, dist_inv_step::FT, dist_offset::FT, dist_step::FT,
@@ -766,9 +746,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_cols_u32!(
     shared_ui = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_uj = @localmem FT (256,)
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
@@ -778,9 +757,8 @@ KA.@kernel function _sf6_single_pass_2d_kernel_tiled128_log_log_val_cols_u32!(
         _sp2d_tiled_load_tile!(shared_xi, shared_ui, shared_xj, shared_uj, x_mat, u_mat, ti, tj, i0, j0, ni, nj, N_points, lid, workgroup_size)
     end
     @synchronize
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
     if bid <= n_tile_blocks
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1

--- a/ext/gpu/kernels_batch.jl
+++ b/ext/gpu/kernels_batch.jl
@@ -1,8 +1,23 @@
 # Production batch tiled128 kernels — fixed-x u-smem strips + block-private merge.
 # Included from StructureFunctionsGPUExt.jl after GPUBatchWorkspace.jl.
 
-"""u-smem strip width for individual 1D batch (fits 48 KiB with xi/xj + ui/uj staging)."""
+"""u-smem strip width for small-strip reference (`_batch_fixed_x_usmem_priv!`)."""
 const BATCH_USMEM_STRIP_W = 16
+
+"""Warps per batch tile block (`SF_GPU_TILED_WS ÷ 32`)."""
+const BATCH_USMEM_WARPS = SF_GPU_TILED_WS ÷ 32
+
+@inline _batch_warp_id(lid::Int) = (lid - 1) >> 5
+
+"""`partial_{sums,cnts}` third-axis length: one slot per `(tile_block, warp)`."""
+@inline _batch_usmem_n_priv(n_tile_blocks::Int) = n_tile_blocks * BATCH_USMEM_WARPS
+
+@inline _batch_usmem_priv_idx(block_id::Int, lid::Int) =
+    (block_id - 1) * BATCH_USMEM_WARPS + _batch_warp_id(lid) + 1
+
+"""Production fixed-x 1D batch kernel (u staged in shared memory, strip 16)."""
+_batch_fixed_x_sf_kernel(backend::KA.Backend, ws::Int) =
+    _batch_fixed_x_usmem_priv!(backend, ws)
 
 """
 SP1D batch strip width — smaller than `BATCH_USMEM_STRIP_W` because on-chip hist is
@@ -21,35 +36,118 @@ end
     return c + 2 * (k - 1) + SF_GPU_TILE * 2 * (col - 1)
 end
 
+"""Stage strip `u` into `shared_ui` with coalesced global loads along the N index."""
+@inline function _stage_batch_ui_tile!(
+    shared_ui,
+    u_batch,
+    b_base::Int,
+    bw::Int,
+    i0::Int,
+    ni::Int,
+    workgroup_size::Int,
+    lid::Int,
+)
+    col = 1
+    while col <= bw
+        b_idx = b_base + col - 1
+        k = lid
+        while k <= ni
+            gi = i0 + k - 1
+            @inbounds begin
+                shared_ui[_batch_usmem_idx(1, k, col)] = u_batch[b_idx, gi, 1]
+                shared_ui[_batch_usmem_idx(2, k, col)] = u_batch[b_idx, gi, 2]
+            end
+            k += workgroup_size
+        end
+        col += 1
+    end
+    return nothing
+end
+
+@inline _gpu_pow_int(x, ::Val{0}) = one(x)
+@inline _gpu_pow_int(x, ::Val{1}) = x
+@inline _gpu_pow_int(x, ::Val{2}) = x * x
+@inline _gpu_pow_int(x, ::Val{3}) = x * x * x
+@inline _gpu_pow_int(x, ::Val{N}) where {N} = x^N
+
+@inline function _gpu_sf_value_2d(::SFT.ProjectedStructureFunctionType{NL, NT}, du_x, du_y, rx, ry) where {NL, NT}
+    du_L = rx * du_x + ry * du_y
+    du_T = ry * du_x - rx * du_y
+    val = one(du_L)
+    if NL != 0
+        val *= _gpu_pow_int(du_L, Val(NL))
+    end
+    if NT != 0
+        val *= _gpu_pow_int(du_T, Val(NT))
+    end
+    return val
+end
+
+@inline function _gpu_sf_value_2d(::SFT.SecondOrderStructureFunctionType, du_x, du_y, rx, ry)
+    return du_x * du_x + du_y * du_y
+end
+
+@inline function _gpu_sf_value_2d(::SFT.ThirdOrderStructureFunctionType, du_x, du_y, rx, ry)
+    du_L = rx * du_x + ry * du_y
+    return du_L * (du_x * du_x + du_y * du_y)
+end
+
+@inline function _gpu_sf_value_2d(::SFT.FullVectorStructureFunctionType{NF}, du_x, du_y, rx, ry) where {NF}
+    n2 = du_x * du_x + du_y * du_y
+    NF == 2 && return n2
+    return _gpu_pow_int(sqrt(n2), Val(NF))
+end
+
+@inline function _gpu_sf_value_2d(::SFT.TransverseComponentSecondOrderStructureFunctionType, du_x, du_y, rx, ry)
+    du_L = rx * du_x + ry * du_y
+    return du_x * du_x + du_y * du_y - du_L * du_L
+end
+
+@inline function _gpu_sf_value_2d(::SFT.LongitudinalTransverseComponentThirdOrderStructureFunctionType, du_x, du_y, rx, ry)
+    du_L = rx * du_x + ry * du_y
+    du_T2 = du_x * du_x + du_y * du_y - du_L * du_L
+    return du_L * du_T2
+end
+
+@inline function _batch_dist_bin(
+    dist::T, fe::T, le::T, is_::T, off::T, sv::T, nb::Int, ::Val{false},
+) where {T}
+    return _gpu_digitize_linear(dist, fe, le, is_, off, sv, nb)
+end
+@inline function _batch_dist_bin(
+    dist::T, fe::T, le::T, is_::T, off::T, sv::T, nb::Int, ::Val{true},
+) where {T}
+    return _gpu_digitize_log_spaced(dist, fe, le, is_, off, sv, nb)
+end
+
 @inline function _pair_bin_rhat_from_smem!(
-    shared_xi,
-    shared_xj,
+    shared_xi::AbstractVector{FT},
+    shared_xj::AbstractVector{FT},
     ia::Int,
     jb::Int,
-    off_diag::Bool,
+    ::Val{OFF_DIAG},
     first_edge::FT,
     last_edge::FT,
     inv_step::FT,
     offset::FT,
     step_val::FT,
     N_bins::Int,
-    ::Type{FT},
-) where {FT}
-    if off_diag
-        X1 = SA.SVector{2, FT}(shared_xi[ia], shared_xi[SF_GPU_TILE + ia])
-        X2 = SA.SVector{2, FT}(shared_xj[jb], shared_xj[SF_GPU_TILE + jb])
+    ::Val{LOG} = Val(false),
+) where {FT, OFF_DIAG, LOG}
+    if OFF_DIAG
+        dx = shared_xj[jb] - shared_xi[ia]
+        dy = shared_xj[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
     else
-        X1 = SA.SVector{2, FT}(shared_xi[ia], shared_xi[SF_GPU_TILE + ia])
-        X2 = SA.SVector{2, FT}(shared_xi[jb], shared_xi[SF_GPU_TILE + jb])
+        dx = shared_xi[jb] - shared_xi[ia]
+        dy = shared_xi[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
     end
-    dX = X2 - X1
-    dist_sq = dX[1]^2 + dX[2]^2
+    dist_sq = dx * dx + dy * dy
     dist = sqrt(dist_sq)
-    bin = _gpu_digitize_linear(dist, first_edge, last_edge, inv_step, offset, step_val, N_bins)
+    bin = _batch_dist_bin(dist, first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG))
     if 1 <= bin < N_bins
-        return (true, bin, dX / dist)
+        return (true, bin, dx / dist, dy / dist)
     end
-    return (false, bin, SA.SVector{2, FT}(zero(FT), zero(FT)))
+    return (false, bin, zero(FT), zero(FT))
 end
 
 """Stage host batch inputs. Fixed-x: `u` → `(B, N, N_dims)` batch-major."""
@@ -72,7 +170,7 @@ function _stage_batch_device(backend::KA.Backend, x::AbstractArray{FT}, u::Abstr
     end
 end
 
-KA.@kernel function _batch_merge_usmem_sums!(
+KA.@kernel unsafe_indices=true function _batch_merge_usmem_sums!(
     output,
     @Const(partial_sums),
     NB::Int,
@@ -96,7 +194,49 @@ KA.@kernel function _batch_merge_usmem_sums!(
     end
 end
 
-KA.@kernel function _batch_merge_usmem_cnts!(
+"""Parallel workgroup reduction merge for CUDA fixed-x batch routes."""
+KA.@kernel unsafe_indices=true function _batch_merge_usmem_sums_grouped!(
+    output,
+    @Const(partial_sums),
+    NB::Int,
+    bw::Int,
+    n_priv::Int,
+    workgroup_size::Int,
+)
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    gid = (g - 1) ÷ workgroup_size + 1
+    shared_acc = @localmem eltype(output) (256,)
+    n_out = NB * bw
+    if gid <= n_out
+        rem0 = gid - 1
+        bin = rem0 % NB + 1
+        col = rem0 ÷ NB + 1
+        acc_s = zero(eltype(output))
+        blk = lid
+        @inbounds while blk <= n_priv
+            acc_s += partial_sums[bin, col, blk]
+            blk += workgroup_size
+        end
+        shared_acc[lid] = acc_s
+        @synchronize
+        g = @index(Global, Linear)
+        lid = (g - 1) % workgroup_size + 1
+        gid = (g - 1) ÷ workgroup_size + 1
+        if gid <= n_out && lid == 1
+            rem0 = gid - 1
+            bin = rem0 % NB + 1
+            col = rem0 ÷ NB + 1
+            total = zero(eltype(output))
+            @inbounds for t in 1:workgroup_size
+                total += shared_acc[t]
+            end
+            @inbounds output[bin, col] = total
+        end
+    end
+end
+
+KA.@kernel unsafe_indices=true function _batch_merge_usmem_cnts!(
     output_cnts,
     @Const(partial_cnts),
     NB::Int,
@@ -116,7 +256,66 @@ KA.@kernel function _batch_merge_usmem_cnts!(
     end
 end
 
-KA.@kernel function _batch_merge_sp1d_sums!(
+KA.@kernel unsafe_indices=true function _batch_merge_usmem_cnts_grouped!(
+    output_cnts,
+    @Const(partial_cnts),
+    NB::Int,
+    n_priv::Int,
+    workgroup_size::Int,
+)
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    gid = (g - 1) ÷ workgroup_size + 1
+    shared_acc = @localmem UInt32 (256,)
+    if gid <= NB
+        bin = gid
+        acc_c = UInt32(0)
+        blk = lid
+        @inbounds while blk <= n_priv
+            acc_c += partial_cnts[bin, blk]
+            blk += workgroup_size
+        end
+        shared_acc[lid] = acc_c
+        @synchronize
+        g = @index(Global, Linear)
+        lid = (g - 1) % workgroup_size + 1
+        gid = (g - 1) ÷ workgroup_size + 1
+        if gid <= NB && lid == 1
+            bin = gid
+            total = UInt32(0)
+            @inbounds for t in 1:workgroup_size
+                total += shared_acc[t]
+            end
+            @inbounds output_cnts[bin] = total
+        end
+    end
+end
+
+KA.@kernel unsafe_indices=true function _batch_merge_usmem_cnts_by_col!(
+    output_cnts,
+    @Const(partial_cnts),
+    NB::Int,
+    bw::Int,
+    n_priv::Int,
+    nworkers::Int,
+)
+    worker = @index(Global, Linear)
+    n_out = NB * bw
+    t = worker
+    while t <= n_out
+        rem0 = t - 1
+        bin = rem0 % NB + 1
+        col = rem0 ÷ NB + 1
+        acc_c = UInt32(0)
+        @inbounds for blk in 1:n_priv
+            acc_c += partial_cnts[bin, col, blk]
+        end
+        @inbounds output_cnts[bin, col] = acc_c
+        t += nworkers
+    end
+end
+
+KA.@kernel unsafe_indices=true function _batch_merge_sp1d_sums!(
     output,
     @Const(partial_sums),
     NB::Int,
@@ -142,7 +341,52 @@ KA.@kernel function _batch_merge_sp1d_sums!(
     end
 end
 
-KA.@kernel function _batch_merge_sp1d_cnts!(
+KA.@kernel unsafe_indices=true function _batch_merge_sp1d_sums_grouped!(
+    output,
+    @Const(partial_sums),
+    NB::Int,
+    bw::Int,
+    n_priv::Int,
+    workgroup_size::Int,
+)
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    gid = (g - 1) ÷ workgroup_size + 1
+    shared_acc = @localmem eltype(output) (256,)
+    n_out = SF_GPU_SINGLE_PASS_N * NB * bw
+    if gid <= n_out
+        rem0 = gid - 1
+        bin = rem0 % NB + 1
+        rem1 = rem0 ÷ NB
+        ty = rem1 % SF_GPU_SINGLE_PASS_N + 1
+        col = rem1 ÷ SF_GPU_SINGLE_PASS_N + 1
+        acc_s = zero(eltype(output))
+        blk = lid
+        @inbounds while blk <= n_priv
+            acc_s += partial_sums[ty, bin, col, blk]
+            blk += workgroup_size
+        end
+        shared_acc[lid] = acc_s
+        @synchronize
+        g = @index(Global, Linear)
+        lid = (g - 1) % workgroup_size + 1
+        gid = (g - 1) ÷ workgroup_size + 1
+        if gid <= n_out && lid == 1
+            rem0 = gid - 1
+            bin = rem0 % NB + 1
+            rem1 = rem0 ÷ NB
+            ty = rem1 % SF_GPU_SINGLE_PASS_N + 1
+            col = rem1 ÷ SF_GPU_SINGLE_PASS_N + 1
+            total = zero(eltype(output))
+            @inbounds for t in 1:workgroup_size
+                total += shared_acc[t]
+            end
+            @inbounds output[ty, bin, col] = total
+        end
+    end
+end
+
+KA.@kernel unsafe_indices=true function _batch_merge_sp1d_cnts!(
     output_cnts,
     @Const(partial_cnts),
     NB::Int,
@@ -165,7 +409,47 @@ KA.@kernel function _batch_merge_sp1d_cnts!(
     end
 end
 
-KA.@kernel function _batch_merge_sp2d_cnts!(
+KA.@kernel unsafe_indices=true function _batch_merge_sp1d_cnts_grouped!(
+    output_cnts,
+    @Const(partial_cnts),
+    NB::Int,
+    n_priv::Int,
+    workgroup_size::Int,
+)
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    gid = (g - 1) ÷ workgroup_size + 1
+    shared_acc = @localmem UInt32 (256,)
+    n_out = SF_GPU_SINGLE_PASS_N * NB
+    if gid <= n_out
+        rem0 = gid - 1
+        bin = rem0 % NB + 1
+        ty = rem0 ÷ NB + 1
+        acc_c = UInt32(0)
+        blk = lid
+        @inbounds while blk <= n_priv
+            acc_c += partial_cnts[ty, bin, blk]
+            blk += workgroup_size
+        end
+        shared_acc[lid] = acc_c
+        @synchronize
+        g = @index(Global, Linear)
+        lid = (g - 1) % workgroup_size + 1
+        gid = (g - 1) ÷ workgroup_size + 1
+        if gid <= n_out && lid == 1
+            rem0 = gid - 1
+            bin = rem0 % NB + 1
+            ty = rem0 ÷ NB + 1
+            total = UInt32(0)
+            @inbounds for t in 1:workgroup_size
+                total += shared_acc[t]
+            end
+            @inbounds output_cnts[ty, bin] = total
+        end
+    end
+end
+
+KA.@kernel unsafe_indices=true function _batch_merge_sp2d_cnts!(
     output_cnts,
     @Const(partial_cnts),
     n_dist::Int,
@@ -194,7 +478,57 @@ KA.@kernel function _batch_merge_sp2d_cnts!(
     end
 end
 
-KA.@kernel function _batch_merge_sp2d_sums!(
+KA.@kernel unsafe_indices=true function _batch_merge_sp2d_cnts_grouped!(
+    output_cnts,
+    @Const(partial_cnts),
+    n_dist::Int,
+    n_val::Int,
+    bw::Int,
+    n_priv::Int,
+    workgroup_size::Int,
+)
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    gid = (g - 1) ÷ workgroup_size + 1
+    shared_acc = @localmem UInt32 (256,)
+    n_out = SF_GPU_SINGLE_PASS_N * n_dist * n_val * bw
+    if gid <= n_out
+        rem0 = gid - 1
+        vbin = rem0 % n_val + 1
+        rem1 = rem0 ÷ n_val
+        dbin = rem1 % n_dist + 1
+        rem2 = rem1 ÷ n_dist
+        ty = rem2 % SF_GPU_SINGLE_PASS_N + 1
+        col = rem2 ÷ SF_GPU_SINGLE_PASS_N + 1
+        acc_c = UInt32(0)
+        blk = lid
+        @inbounds while blk <= n_priv
+            acc_c += partial_cnts[ty, dbin, vbin, col, blk]
+            blk += workgroup_size
+        end
+        shared_acc[lid] = acc_c
+        @synchronize
+        g = @index(Global, Linear)
+        lid = (g - 1) % workgroup_size + 1
+        gid = (g - 1) ÷ workgroup_size + 1
+        if gid <= n_out && lid == 1
+            rem0 = gid - 1
+            vbin = rem0 % n_val + 1
+            rem1 = rem0 ÷ n_val
+            dbin = rem1 % n_dist + 1
+            rem2 = rem1 ÷ n_dist
+            ty = rem2 % SF_GPU_SINGLE_PASS_N + 1
+            col = rem2 ÷ SF_GPU_SINGLE_PASS_N + 1
+            total = UInt32(0)
+            @inbounds for t in 1:workgroup_size
+                total += shared_acc[t]
+            end
+            @inbounds output_cnts[ty, dbin, vbin, col] = total
+        end
+    end
+end
+
+KA.@kernel unsafe_indices=true function _batch_merge_sp2d_sums!(
     output,
     @Const(partial_sums),
     n_dist::Int,
@@ -223,25 +557,76 @@ KA.@kernel function _batch_merge_sp2d_sums!(
     end
 end
 
+KA.@kernel unsafe_indices=true function _batch_merge_sp2d_sums_grouped!(
+    output,
+    @Const(partial_sums),
+    n_dist::Int,
+    n_val::Int,
+    bw::Int,
+    n_priv::Int,
+    workgroup_size::Int,
+)
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    gid = (g - 1) ÷ workgroup_size + 1
+    shared_acc = @localmem eltype(output) (256,)
+    n_out = SF_GPU_SINGLE_PASS_N * n_dist * n_val * bw
+    if gid <= n_out
+        rem0 = gid - 1
+        vbin = rem0 % n_val + 1
+        rem1 = rem0 ÷ n_val
+        dbin = rem1 % n_dist + 1
+        rem2 = rem1 ÷ n_dist
+        ty = rem2 % SF_GPU_SINGLE_PASS_N + 1
+        col = rem2 ÷ SF_GPU_SINGLE_PASS_N + 1
+        acc_s = zero(eltype(output))
+        blk = lid
+        @inbounds while blk <= n_priv
+            acc_s += partial_sums[ty, dbin, vbin, col, blk]
+            blk += workgroup_size
+        end
+        shared_acc[lid] = acc_s
+        @synchronize
+        g = @index(Global, Linear)
+        lid = (g - 1) % workgroup_size + 1
+        gid = (g - 1) ÷ workgroup_size + 1
+        if gid <= n_out && lid == 1
+            rem0 = gid - 1
+            vbin = rem0 % n_val + 1
+            rem1 = rem0 ÷ n_val
+            dbin = rem1 % n_dist + 1
+            rem2 = rem1 ÷ n_dist
+            ty = rem2 % SF_GPU_SINGLE_PASS_N + 1
+            col = rem2 ÷ SF_GPU_SINGLE_PASS_N + 1
+            total = zero(eltype(output))
+            @inbounds for t in 1:workgroup_size
+                total += shared_acc[t]
+            end
+            @inbounds output[ty, dbin, vbin, col] = total
+        end
+    end
+end
+
 @inline function _batch_sp1d_accum_shared!(
     shared_sums,
     shared_cnts,
     bin::Int,
     col::Int,
     du_L,
-    du_T,
     du_L2,
     du_T2,
-    NB::Int,
+    du_norm2,
+    NB::Int;
+    track_counts::Bool = true,
 )
     base = (col - 1) * SF_GPU_SINGLE_PASS_N * NB
-    @atomic shared_sums[base + bin] += du_L2 + du_T2
+    @atomic shared_sums[base + bin] += du_norm2
     @atomic shared_sums[base + NB + bin] += du_L2
     @atomic shared_sums[base + 2NB + bin] += du_T2
-    @atomic shared_sums[base + 3NB + bin] += du_L * (du_L2 + du_T2)
+    @atomic shared_sums[base + 3NB + bin] += du_L * du_norm2
     @atomic shared_sums[base + 4NB + bin] += du_L * du_L2
-     shared_sums[base + 5NB + bin] += du_L * du_T2
-    if col == 1
+    @atomic shared_sums[base + 5NB + bin] += du_L * du_T2
+    if track_counts && col == 1
         @atomic shared_cnts[bin] += UInt32(1)
     end
     return nothing
@@ -249,9 +634,13 @@ end
 
 # ---------------------------------------------------------------------------
 # Fixed-x individual SF — u-smem priv strip kernel
+#
+# Histogram levels (warp-private partials do not fit in smem on sm_80 — 48 KiB cap):
+#   1. Pair loop: `@atomic` into `partial_sums[bin, col, priv_idx]` (32 threads / priv slot).
+#   2. Host merge kernel: sum all `priv_idx` → strip output (`_batch_merge_usmem_*`, `n_priv` axis).
 # ---------------------------------------------------------------------------
 
-KA.@kernel function _batch_fixed_x_usmem_priv!(
+KA.@kernel unsafe_indices=true function _batch_fixed_x_usmem_priv!(
     partial_sums,
     partial_cnts,
     @Const(x_mat),
@@ -270,12 +659,169 @@ KA.@kernel function _batch_fixed_x_usmem_priv!(
     n_tiles::Int,
     n_tile_blocks::Int,
     workgroup_size::Int,
-) where {FT}
+    ::Val{LOG} = Val(false),
+) where {FT, LOG}
     shared_xi = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_ui = @localmem FT (256 * BATCH_USMEM_STRIP_W,)
     shared_uj = @localmem FT (256 * BATCH_USMEM_STRIP_W,)
-    shared_sums = @localmem FT (SF_GPU_MAX_BINS * BATCH_USMEM_STRIP_W,)
+
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    bid = (g - 1) ÷ workgroup_size + 1
+    block_id = bid
+
+    if bid <= n_tile_blocks
+        priv_idx = _batch_usmem_priv_idx(block_id, lid)
+        slot = lid
+        while slot <= NB * bw
+            bin = (slot - 1) % NB + 1
+            col = (slot - 1) ÷ NB + 1
+            @inbounds partial_sums[bin, col, priv_idx] = zero(FT)
+            slot += workgroup_size
+        end
+        if b_base == 1
+            slot = lid
+            while slot <= NB
+                @inbounds partial_cnts[slot, priv_idx] = UInt32(0)
+                slot += workgroup_size
+            end
+        end
+    end
+
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds begin
+                    shared_xi[k] = x_mat[1, gi]
+                    shared_xi[SF_GPU_TILE + k] = x_mat[2, gi]
+                end
+                k += workgroup_size
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds begin
+                        shared_xj[k] = x_mat[1, gj]
+                        shared_xj[SF_GPU_TILE + k] = x_mat[2, gj]
+                    end
+                    k += workgroup_size
+                end
+            end
+            _stage_batch_ui_tile!(shared_ui, u_batch, b_base, bw, i0, ni, workgroup_size, lid)
+            if ti < tj
+                _stage_batch_ui_tile!(shared_uj, u_batch, b_base, bw, j0, nj, workgroup_size, lid)
+            end
+        end
+    end
+    @synchronize
+
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    bid = (g - 1) ÷ workgroup_size + 1
+    block_id = bid
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            if ti < tj
+                n_pairs = ni * nj
+                p = lid
+                while p <= n_pairs
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    pair_ok, bin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(true),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
+                    )
+                    if pair_ok
+                        priv_idx = _batch_usmem_priv_idx(block_id, lid)
+                        @inbounds for col in 1:bw
+                            du_x = shared_uj[_batch_usmem_idx(1, jb, col)] - shared_ui[_batch_usmem_idx(1, ia, col)]
+                            du_y = shared_uj[_batch_usmem_idx(2, jb, col)] - shared_ui[_batch_usmem_idx(2, ia, col)]
+                            val = _gpu_sf_value_2d(sf_type, du_x, du_y, rx, ry)
+                            @atomic partial_sums[bin, col, priv_idx] += val
+                        end
+                        if b_base == 1
+                            @atomic partial_cnts[bin, priv_idx] += UInt32(1)
+                        end
+                    end
+                    p += workgroup_size
+                end
+            else
+                n_pairs = ni * (ni - 1) ÷ 2
+                p = lid
+                while p <= n_pairs
+                    ia, jb = _pair_from_linear(p, ni)
+                    pair_ok, bin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(false),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
+                    )
+                    if pair_ok
+                        priv_idx = _batch_usmem_priv_idx(block_id, lid)
+                        @inbounds for col in 1:bw
+                            du_x = shared_ui[_batch_usmem_idx(1, jb, col)] - shared_ui[_batch_usmem_idx(1, ia, col)]
+                            du_y = shared_ui[_batch_usmem_idx(2, jb, col)] - shared_ui[_batch_usmem_idx(2, ia, col)]
+                            val = _gpu_sf_value_2d(sf_type, du_x, du_y, rx, ry)
+                            @atomic partial_sums[bin, col, priv_idx] += val
+                        end
+                        if b_base == 1
+                            @atomic partial_cnts[bin, priv_idx] += UInt32(1)
+                        end
+                    end
+                    p += workgroup_size
+                end
+            end
+        end
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Fixed-x individual SF — global-`u` strip kernel (WITHDRAWN — not used in launch)
+#
+# A100 Mar 2026: strip 128 / 63 sweeps measured ~48 s at NB=50–64 vs ~12 s for usmem
+# strip 16 / 504 sweeps at NB=50. Fewer geometry replays were canceled by 8× more
+# inner-loop atomics per pair and uncached global `u` loads. Do not wire without profiling.
+# ---------------------------------------------------------------------------
+
+"""
+    _batch_fixed_x_global_u_priv!(partial_sums, partial_cnts, ...)
+"""
+KA.@kernel unsafe_indices=true function _batch_fixed_x_global_u_priv!(
+    partial_sums,
+    partial_cnts,
+    @Const(x_mat),
+    @Const(u_batch),
+    sf_type,
+    N_points::Int,
+    N_bins::Int,
+    NB::Int,
+    b_base::Int,
+    bw::Int,
+    first_edge::FT,
+    last_edge::FT,
+    inv_step::FT,
+    offset::FT,
+    step_val::FT,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    workgroup_size::Int,
+    ::Val{LOG} = Val(false),
+) where {FT, LOG}
+    shared_xi = @localmem FT (256,)
+    shared_xj = @localmem FT (256,)
+    shared_sums = @localmem FT (SF_GPU_MAX_BINS * 128,)
     shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
 
     g = @index(Global, Linear)
@@ -323,38 +869,6 @@ KA.@kernel function _batch_fixed_x_usmem_priv!(
                     k += workgroup_size
                 end
             end
-            elem = lid
-            while elem <= 256 * bw
-                col = (elem - 1) ÷ 256 + 1
-                rem = (elem - 1) % 256
-                k = rem ÷ 2 + 1
-                c = rem % 2 + 1
-                gi = i0 + k - 1
-                b_idx = b_base + col - 1
-                if k <= ni
-                    @inbounds shared_ui[elem] = u_batch[b_idx, gi, c]
-                else
-                    @inbounds shared_ui[elem] = zero(FT)
-                end
-                elem += workgroup_size
-            end
-            if ti < tj
-                elem = lid
-                while elem <= 256 * bw
-                    col = (elem - 1) ÷ 256 + 1
-                    rem = (elem - 1) % 256
-                    k = rem ÷ 2 + 1
-                    c = rem % 2 + 1
-                    gj = j0 + k - 1
-                    b_idx = b_base + col - 1
-                    if k <= nj
-                        @inbounds shared_uj[elem] = u_batch[b_idx, gj, c]
-                    else
-                        @inbounds shared_uj[elem] = zero(FT)
-                    end
-                    elem += workgroup_size
-                end
-            end
         end
     end
     @synchronize
@@ -376,21 +890,18 @@ KA.@kernel function _batch_fixed_x_usmem_priv!(
                 while p <= n_pairs
                     ia = (p - 1) ÷ nj + 1
                     jb = (p - 1) - (ia - 1) * nj + 1
-                    pair_ok, bin, r̂ = _pair_bin_rhat_from_smem!(
-                        shared_xi, shared_xj, ia, jb, true,
-                        first_edge, last_edge, inv_step, offset, step_val, N_bins, FT,
+                    pair_ok, bin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(true),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
                     )
                     if pair_ok
+                        gi = i0 + ia - 1
+                        gj = j0 + jb - 1
                         @inbounds for col in 1:bw
-                            U1 = SA.SVector{2, FT}(
-                                shared_ui[_batch_usmem_idx(1, ia, col)],
-                                shared_ui[_batch_usmem_idx(2, ia, col)],
-                            )
-                            U2 = SA.SVector{2, FT}(
-                                shared_uj[_batch_usmem_idx(1, jb, col)],
-                                shared_uj[_batch_usmem_idx(2, jb, col)],
-                            )
-                            val = sf_type(U2 - U1, r̂)
+                            b_idx = b_base + col - 1
+                            du_x = u_batch[b_idx, gj, 1] - u_batch[b_idx, gi, 1]
+                            du_y = u_batch[b_idx, gj, 2] - u_batch[b_idx, gi, 2]
+                            val = _gpu_sf_value_2d(sf_type, du_x, du_y, rx, ry)
                             hist_slot = bin + (col - 1) * NB
                             @atomic shared_sums[hist_slot] += val
                         end
@@ -405,21 +916,18 @@ KA.@kernel function _batch_fixed_x_usmem_priv!(
                 p = lid
                 while p <= n_pairs
                     ia, jb = _pair_from_linear(p, ni)
-                    pair_ok, bin, r̂ = _pair_bin_rhat_from_smem!(
-                        shared_xi, shared_xj, ia, jb, false,
-                        first_edge, last_edge, inv_step, offset, step_val, N_bins, FT,
+                    pair_ok, bin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(false),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
                     )
                     if pair_ok
+                        gi = i0 + ia - 1
+                        gj = i0 + jb - 1
                         @inbounds for col in 1:bw
-                            U1 = SA.SVector{2, FT}(
-                                shared_ui[_batch_usmem_idx(1, ia, col)],
-                                shared_ui[_batch_usmem_idx(2, ia, col)],
-                            )
-                            U2 = SA.SVector{2, FT}(
-                                shared_ui[_batch_usmem_idx(1, jb, col)],
-                                shared_ui[_batch_usmem_idx(2, jb, col)],
-                            )
-                            val = sf_type(U2 - U1, r̂)
+                            b_idx = b_base + col - 1
+                            du_x = u_batch[b_idx, gj, 1] - u_batch[b_idx, gi, 1]
+                            du_y = u_batch[b_idx, gj, 2] - u_batch[b_idx, gi, 2]
+                            val = _gpu_sf_value_2d(sf_type, du_x, du_y, rx, ry)
                             hist_slot = bin + (col - 1) * NB
                             @atomic shared_sums[hist_slot] += val
                         end
@@ -457,10 +965,10 @@ KA.@kernel function _batch_fixed_x_usmem_priv!(
 end
 
 # ---------------------------------------------------------------------------
-# Fixed-x SP1D (8 types) — u-smem priv strip kernel
+# Fixed-x SP1D (six invariants) — u-smem priv strip kernel
 # ---------------------------------------------------------------------------
 
-KA.@kernel function _batch_fixed_x_sp1d_usmem_priv!(
+KA.@kernel unsafe_indices=true function _batch_fixed_x_sp1d_usmem_priv!(
     partial_sums,
     partial_cnts,
     @Const(x_mat),
@@ -478,7 +986,8 @@ KA.@kernel function _batch_fixed_x_sp1d_usmem_priv!(
     n_tiles::Int,
     n_tile_blocks::Int,
     workgroup_size::Int,
-) where {FT}
+    ::Val{LOG} = Val(false),
+) where {FT, LOG}
     shared_xi = @localmem FT (256,)
     shared_xj = @localmem FT (256,)
     shared_ui = @localmem FT (256 * BATCH_SP1D_USMEM_STRIP_W,)
@@ -584,21 +1093,21 @@ KA.@kernel function _batch_fixed_x_sp1d_usmem_priv!(
                 while p <= n_pairs
                     ia = (p - 1) ÷ nj + 1
                     jb = (p - 1) - (ia - 1) * nj + 1
-                    pair_ok, bin, r̂ = _pair_bin_rhat_from_smem!(
-                        shared_xi, shared_xj, ia, jb, true,
-                        first_edge, last_edge, inv_step, offset, step_val, N_bins, FT,
+                    pair_ok, bin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(true),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
                     )
                     if pair_ok
                         @inbounds for col in 1:bw
                             du_x = shared_uj[_batch_usmem_idx(1, jb, col)] - shared_ui[_batch_usmem_idx(1, ia, col)]
                             du_y = shared_uj[_batch_usmem_idx(2, jb, col)] - shared_ui[_batch_usmem_idx(2, ia, col)]
-                            du_L = r̂[1] * du_x + r̂[2] * du_y
-                            du_T = r̂[2] * du_x - r̂[1] * du_y
+                            du_L = rx * du_x + ry * du_y
                             du_L2 = du_L * du_L
-                            du_T2 = du_T * du_T
+                            du_norm2 = du_x * du_x + du_y * du_y
+                            du_T2 = du_norm2 - du_L2
                             _batch_sp1d_accum_shared!(
                                 shared_sums, shared_cnts, bin, col,
-                                du_L, du_T, du_L2, du_T2, NB,
+                                du_L, du_L2, du_T2, du_norm2, NB,
                             )
                         end
                     end
@@ -609,21 +1118,21 @@ KA.@kernel function _batch_fixed_x_sp1d_usmem_priv!(
                 p = lid
                 while p <= n_pairs
                     ia, jb = _pair_from_linear(p, ni)
-                    pair_ok, bin, r̂ = _pair_bin_rhat_from_smem!(
-                        shared_xi, shared_xj, ia, jb, false,
-                        first_edge, last_edge, inv_step, offset, step_val, N_bins, FT,
+                    pair_ok, bin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(false),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
                     )
                     if pair_ok
                         @inbounds for col in 1:bw
                             du_x = shared_ui[_batch_usmem_idx(1, jb, col)] - shared_ui[_batch_usmem_idx(1, ia, col)]
                             du_y = shared_ui[_batch_usmem_idx(2, jb, col)] - shared_ui[_batch_usmem_idx(2, ia, col)]
-                            du_L = r̂[1] * du_x + r̂[2] * du_y
-                            du_T = r̂[2] * du_x - r̂[1] * du_y
+                            du_L = rx * du_x + ry * du_y
                             du_L2 = du_L * du_L
-                            du_T2 = du_T * du_T
+                            du_norm2 = du_x * du_x + du_y * du_y
+                            du_T2 = du_norm2 - du_L2
                             _batch_sp1d_accum_shared!(
                                 shared_sums, shared_cnts, bin, col,
-                                du_L, du_T, du_L2, du_T2, NB,
+                                du_L, du_L2, du_T2, du_norm2, NB,
                             )
                         end
                     end
@@ -663,10 +1172,164 @@ KA.@kernel function _batch_fixed_x_sp1d_usmem_priv!(
 end
 
 # ---------------------------------------------------------------------------
-# Varying geometry — one launch, geometry per (pair, b)
+# Fixed-x SP2D — shared x, u strip, partial block-private outputs
 # ---------------------------------------------------------------------------
 
-KA.@kernel function _batch_varying_x_sf!(
+KA.@kernel unsafe_indices=true function _batch_varying_x_sp2d_fixed_x!(
+    partial_sums,
+    partial_cnts,
+    @Const(x_mat),
+    @Const(u_batch),
+    N_points::Int,
+    N_bins::Int,
+    n_dist::Int,
+    n_val::Int,
+    b_base::Int,
+    bw::Int,
+    first_edge::FT,
+    last_edge::FT,
+    inv_step::FT,
+    offset::FT,
+    step_val::FT,
+    val_plan::GPUValueDigitizePlan,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    workgroup_size::Int,
+    ::Val{LOG} = Val(false),
+) where {FT, LOG}
+    shared_xi = @localmem FT (256,)
+    shared_xj = @localmem FT (256,)
+    shared_ui = @localmem FT (BATCH_USMEM_STRIP_W * SF_GPU_TILE * 2,)
+    shared_uj = @localmem FT (BATCH_USMEM_STRIP_W * SF_GPU_TILE * 2,)
+
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    bid = (g - 1) ÷ workgroup_size + 1
+    block_id = bid
+
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds begin
+                    shared_xi[k]               = x_mat[1, gi]
+                    shared_xi[SF_GPU_TILE + k] = x_mat[2, gi]
+                end
+                k += workgroup_size
+            end
+            _stage_batch_ui_tile!(shared_ui, u_batch, b_base, bw, i0, ni, workgroup_size, lid)
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds begin
+                        shared_xj[k]               = x_mat[1, gj]
+                        shared_xj[SF_GPU_TILE + k] = x_mat[2, gj]
+                    end
+                    k += workgroup_size
+                end
+                _stage_batch_ui_tile!(shared_uj, u_batch, b_base, bw, j0, nj, workgroup_size, lid)
+            end
+        end
+    end
+    @synchronize
+
+    g = @index(Global, Linear)
+    lid = (g - 1) % workgroup_size + 1
+    bid = (g - 1) ÷ workgroup_size + 1
+    block_id = bid
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            n_pairs = ti < tj ? ni * nj : ni * (ni - 1) ÷ 2
+            p = lid
+            while p <= n_pairs
+                if ti < tj
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    pair_ok, dbin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(true),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
+                    )
+                    if pair_ok
+                        @inbounds for col in 1:bw
+                            du_x = shared_uj[_batch_usmem_idx(1, jb, col)] - shared_ui[_batch_usmem_idx(1, ia, col)]
+                            du_y = shared_uj[_batch_usmem_idx(2, jb, col)] - shared_ui[_batch_usmem_idx(2, ia, col)]
+                            du_L     = rx * du_x + ry * du_y
+                            du_L2    = du_L * du_L
+                            du_norm2 = du_x * du_x + du_y * du_y
+                            du_T2    = du_norm2 - du_L2
+                            v1 = du_norm2
+                            v2 = du_L2
+                            v3 = du_T2
+                            v4 = du_L * du_norm2
+                            v5 = du_L * du_L2
+                            v6 = du_L * du_T2
+                            @inbounds for t in 1:SF_GPU_SINGLE_PASS_N
+                                val_t = t == 1 ? v1 : t == 2 ? v2 : t == 3 ? v3 : t == 4 ? v4 : t == 5 ? v5 : v6
+                                vbin = _gpu_digitize_value_plan(val_t, val_plan, t, n_val + 1)
+                                if 1 <= vbin <= n_val
+                                    @atomic partial_sums[t, dbin, vbin, col, block_id] += val_t
+                                    @atomic partial_cnts[t, dbin, vbin, col, block_id] += UInt32(1)
+                                end
+                            end
+                        end
+                    end
+                else
+                    ia, jb = _pair_from_linear(p, ni)
+                    pair_ok, dbin, rx, ry = _pair_bin_rhat_from_smem!(
+                        shared_xi, shared_xj, ia, jb, Val(false),
+                        first_edge, last_edge, inv_step, offset, step_val, N_bins, Val(LOG),
+                    )
+                    if pair_ok
+                        @inbounds for col in 1:bw
+                            du_x = shared_ui[_batch_usmem_idx(1, jb, col)] - shared_ui[_batch_usmem_idx(1, ia, col)]
+                            du_y = shared_ui[_batch_usmem_idx(2, jb, col)] - shared_ui[_batch_usmem_idx(2, ia, col)]
+                            du_L     = rx * du_x + ry * du_y
+                            du_L2    = du_L * du_L
+                            du_norm2 = du_x * du_x + du_y * du_y
+                            du_T2    = du_norm2 - du_L2
+                            v1 = du_norm2
+                            v2 = du_L2
+                            v3 = du_T2
+                            v4 = du_L * du_norm2
+                            v5 = du_L * du_L2
+                            v6 = du_L * du_T2
+                            @inbounds for t in 1:SF_GPU_SINGLE_PASS_N
+                                val_t = t == 1 ? v1 : t == 2 ? v2 : t == 3 ? v3 : t == 4 ? v4 : t == 5 ? v5 : v6
+                                vbin = _gpu_digitize_value_plan(val_t, val_plan, t, n_val + 1)
+                                if 1 <= vbin <= n_val
+                                    @atomic partial_sums[t, dbin, vbin, col, block_id] += val_t
+                                    @atomic partial_cnts[t, dbin, vbin, col, block_id] += UInt32(1)
+                                end
+                            end
+                        end
+                    end
+                end
+                p += workgroup_size
+            end
+        end
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Varying geometry — one launch per (tile, b)
+# ---------------------------------------------------------------------------
+
+"""Tiled varying-x individual SF: stages x and u per tile per batch element into shared memory,
+accumulates into a block-local histogram, then flushes to global output.
+Replaces the naive version which did all reads/writes from global memory."""
+KA.@kernel unsafe_indices=true function _batch_varying_x_sf!(
     output,
     counts,
     @Const(x_batch),
@@ -685,10 +1348,65 @@ KA.@kernel function _batch_varying_x_sf!(
     workgroup_size::Int,
     B::Int,
 ) where {FT}
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
-    if bid <= n_tile_blocks
+    shared_xi  = @localmem FT (256,)
+    shared_xj  = @localmem FT (256,)
+    shared_ui  = @localmem FT (256,)
+    shared_uj  = @localmem FT (256,)
+    shared_sums = @localmem FT (SF_GPU_MAX_BINS,)
+    shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_sums[b_init] = zero(FT)
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
+    end
+
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds begin
+                    shared_xi[k]              = x_batch[1, gi, b]
+                    shared_xi[SF_GPU_TILE + k] = x_batch[2, gi, b]
+                    shared_ui[k]              = u_batch[1, gi, b]
+                    shared_ui[SF_GPU_TILE + k] = u_batch[2, gi, b]
+                end
+                k += workgroup_size
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds begin
+                        shared_xj[k]              = x_batch[1, gj, b]
+                        shared_xj[SF_GPU_TILE + k] = x_batch[2, gj, b]
+                        shared_uj[k]              = u_batch[1, gj, b]
+                        shared_uj[SF_GPU_TILE + k] = u_batch[2, gj, b]
+                    end
+                    k += workgroup_size
+                end
+            end
+        end
+    end
+    @synchronize
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
         j0 = (tj - 1) * SF_GPU_TILE + 1
@@ -701,38 +1419,54 @@ KA.@kernel function _batch_varying_x_sf!(
                 if ti < tj
                     ia = (p - 1) ÷ nj + 1
                     jb = (p - 1) - (ia - 1) * nj + 1
-                    gi = i0 + ia - 1
-                    gj = j0 + jb - 1
+                    dx = shared_xj[jb]              - shared_xi[ia]
+                    dy = shared_xj[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
+                    U1x = shared_ui[ia]; U1y = shared_ui[SF_GPU_TILE + ia]
+                    U2x = shared_uj[jb]; U2y = shared_uj[SF_GPU_TILE + jb]
                 else
                     ia, jb = _pair_from_linear(p, ni)
-                    gi = i0 + ia - 1
-                    gj = i0 + jb - 1
+                    dx = shared_xi[jb]              - shared_xi[ia]
+                    dy = shared_xi[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
+                    U1x = shared_ui[ia]; U1y = shared_ui[SF_GPU_TILE + ia]
+                    U2x = shared_ui[jb]; U2y = shared_ui[SF_GPU_TILE + jb]
                 end
-                @inbounds for b in 1:B
-                    X1 = SA.SVector{2, FT}(x_batch[1, gi, b], x_batch[2, gi, b])
-                    X2 = SA.SVector{2, FT}(x_batch[1, gj, b], x_batch[2, gj, b])
-                    U1 = SA.SVector{2, FT}(u_batch[1, gi, b], u_batch[2, gi, b])
-                    U2 = SA.SVector{2, FT}(u_batch[1, gj, b], u_batch[2, gj, b])
-                    dX = X2 - X1
-                    dist_sq = dX[1]^2 + dX[2]^2
-                    dist = sqrt(dist_sq)
-                    bin = _gpu_digitize_linear(
-                        dist, first_edge, last_edge, inv_step, offset, step_val, N_bins,
-                    )
-                    if 1 <= bin < N_bins
-                        r̂ = dX / dist
-                        val = sf_type(U2 - U1, r̂)
-                        @atomic output[bin, b] += val
-                        @atomic counts[bin, b] += UInt32(1)
-                    end
+                dist_sq = dx * dx + dy * dy
+                dist = sqrt(dist_sq)
+                bin = _gpu_digitize_linear(dist, first_edge, last_edge, inv_step, offset, step_val, N_bins)
+                if 1 <= bin < N_bins
+                    rx = dx / dist; ry = dy / dist
+                    val = _gpu_sf_value_2d(sf_type, U2x - U1x, U2y - U1y, rx, ry)
+                    @atomic shared_sums[bin] += val
+                    @atomic shared_cnts[bin] += UInt32(1)
                 end
                 p += workgroup_size
             end
         end
     end
+    @synchronize
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        flushed = lid
+        while flushed <= NB
+            s = shared_sums[flushed]
+            @atomic output[flushed, b] += s
+            c = shared_cnts[flushed]
+            if c != UInt32(0)
+                @atomic counts[flushed, b] += c
+            end
+            flushed += workgroup_size
+        end
+    end
 end
 
-KA.@kernel function _batch_varying_x_sp1d!(
+"""Tiled varying-x SP1D: stages x and u per tile per batch element into shared memory,
+accumulates into a block-local (6, NB) histogram, then flushes to global output.
+Replaces the naive version that issued 12 global atomics per valid pair."""
+KA.@kernel unsafe_indices=true function _batch_varying_x_sp1d!(
     output_sums,
     output_counts,
     @Const(x_batch),
@@ -750,10 +1484,69 @@ KA.@kernel function _batch_varying_x_sp1d!(
     workgroup_size::Int,
     B::Int,
 ) where {FT}
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
-    if bid <= n_tile_blocks
+    shared_xi  = @localmem FT (256,)
+    shared_xj  = @localmem FT (256,)
+    shared_ui  = @localmem FT (256,)
+    shared_uj  = @localmem FT (256,)
+    shared_sums = @localmem FT (SF_GPU_SINGLE_PASS_N * SF_GPU_MAX_BINS,)
+    shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS,)
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+
+    k_init = lid
+    while k_init <= SF_GPU_SINGLE_PASS_N * NB
+        @inbounds shared_sums[k_init] = zero(FT)
+        k_init += workgroup_size
+    end
+    b_init = lid
+    while b_init <= NB
+        @inbounds shared_cnts[b_init] = UInt32(0)
+        b_init += workgroup_size
+    end
+
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds begin
+                    shared_xi[k]              = x_batch[1, gi, b]
+                    shared_xi[SF_GPU_TILE + k] = x_batch[2, gi, b]
+                    shared_ui[k]              = u_batch[1, gi, b]
+                    shared_ui[SF_GPU_TILE + k] = u_batch[2, gi, b]
+                end
+                k += workgroup_size
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds begin
+                        shared_xj[k]              = x_batch[1, gj, b]
+                        shared_xj[SF_GPU_TILE + k] = x_batch[2, gj, b]
+                        shared_uj[k]              = u_batch[1, gj, b]
+                        shared_uj[SF_GPU_TILE + k] = u_batch[2, gj, b]
+                    end
+                    k += workgroup_size
+                end
+            end
+        end
+    end
+    @synchronize
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
         ti, tj = _tile_from_linear(bid, n_tiles)
         i0 = (ti - 1) * SF_GPU_TILE + 1
         j0 = (tj - 1) * SF_GPU_TILE + 1
@@ -766,39 +1559,186 @@ KA.@kernel function _batch_varying_x_sp1d!(
                 if ti < tj
                     ia = (p - 1) ÷ nj + 1
                     jb = (p - 1) - (ia - 1) * nj + 1
-                    gi = i0 + ia - 1
-                    gj = j0 + jb - 1
+                    dx = shared_xj[jb]              - shared_xi[ia]
+                    dy = shared_xj[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
+                    U1x = shared_ui[ia]; U1y = shared_ui[SF_GPU_TILE + ia]
+                    U2x = shared_uj[jb]; U2y = shared_uj[SF_GPU_TILE + jb]
                 else
                     ia, jb = _pair_from_linear(p, ni)
-                    gi = i0 + ia - 1
-                    gj = i0 + jb - 1
+                    dx = shared_xi[jb]              - shared_xi[ia]
+                    dy = shared_xi[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
+                    U1x = shared_ui[ia]; U1y = shared_ui[SF_GPU_TILE + ia]
+                    U2x = shared_ui[jb]; U2y = shared_ui[SF_GPU_TILE + jb]
                 end
-                @inbounds for b in 1:B
-                    X1 = SA.SVector{2, FT}(x_batch[1, gi, b], x_batch[2, gi, b])
-                    X2 = SA.SVector{2, FT}(x_batch[1, gj, b], x_batch[2, gj, b])
-                    U1 = SA.SVector{2, FT}(u_batch[1, gi, b], u_batch[2, gi, b])
-                    U2 = SA.SVector{2, FT}(u_batch[1, gj, b], u_batch[2, gj, b])
-                    dX = X2 - X1
-                    dist_sq = dX[1]^2 + dX[2]^2
-                    dist = sqrt(dist_sq)
-                    bin = _gpu_digitize_linear(
+                dist_sq = dx * dx + dy * dy
+                dist = sqrt(dist_sq)
+                bin = _gpu_digitize_linear(dist, first_edge, last_edge, inv_step, offset, step_val, N_bins)
+                if 1 <= bin < N_bins
+                    rx = dx / dist; ry = dy / dist
+                    du_x = U2x - U1x; du_y = U2y - U1y
+                    du_L = rx * du_x + ry * du_y
+                    du_L2 = du_L * du_L
+                    du_norm2 = du_x * du_x + du_y * du_y
+                    du_T2 = du_norm2 - du_L2
+                    _gpu_accumulate_single_pass_1d_shared!(
+                        shared_sums, shared_cnts, bin, du_L, du_L2, du_T2, du_norm2, NB,
+                    )
+                end
+                p += workgroup_size
+            end
+        end
+    end
+    @synchronize
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        k = lid
+        while k <= SF_GPU_SINGLE_PASS_N * NB
+            s = shared_sums[k]
+            if s != zero(FT)
+                t   = (k - 1) ÷ NB + 1
+                bin = (k - 1) % NB + 1
+                @atomic output_sums[t, bin, b] += s
+            end
+            k += workgroup_size
+        end
+        cnt_slot = lid
+        while cnt_slot <= NB
+            c = shared_cnts[cnt_slot]
+            if c != UInt32(0)
+                for t in 1:SF_GPU_SINGLE_PASS_N
+                    @atomic output_counts[t, cnt_slot, b] += c
+                end
+            end
+            cnt_slot += workgroup_size
+        end
+    end
+end
+
+"""Tiled varying-x SP2D: stages tile x/u into shared memory to cut global loads per pair
+from 8 down to 0 after the load phase. Output histogram is too large for shared memory
+(n_dist×n_val×6 can exceed 48 KB), so global atomics are used for output."""
+KA.@kernel unsafe_indices=true function _batch_varying_x_sp2d!(
+    output_sums,
+    output_counts,
+    @Const(x_batch),
+    @Const(u_batch),
+    N_points::Int,
+    N_bins::Int,
+    n_dist::Int,
+    n_val::Int,
+    first_edge::FT,
+    last_edge::FT,
+    inv_step::FT,
+    offset::FT,
+    step_val::FT,
+    val_plan::GPUValueDigitizePlan,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    workgroup_size::Int,
+    B::Int,
+) where {FT}
+    shared_xi = @localmem FT (256,)
+    shared_xj = @localmem FT (256,)
+    shared_ui = @localmem FT (256,)
+    shared_uj = @localmem FT (256,)
+
+    lid          = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds begin
+                    shared_xi[k]               = x_batch[1, gi, b]
+                    shared_xi[SF_GPU_TILE + k] = x_batch[2, gi, b]
+                    shared_ui[k]               = u_batch[1, gi, b]
+                    shared_ui[SF_GPU_TILE + k] = u_batch[2, gi, b]
+                end
+                k += workgroup_size
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds begin
+                        shared_xj[k]               = x_batch[1, gj, b]
+                        shared_xj[SF_GPU_TILE + k] = x_batch[2, gj, b]
+                        shared_uj[k]               = u_batch[1, gj, b]
+                        shared_uj[SF_GPU_TILE + k] = u_batch[2, gj, b]
+                    end
+                    k += workgroup_size
+                end
+            end
+        end
+    end
+    @synchronize
+
+    lid          = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b   = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N_points - i0 + 1)
+        nj = min(SF_GPU_TILE, N_points - j0 + 1)
+        if ni > 0 && nj > 0
+            n_pairs = ti < tj ? ni * nj : ni * (ni - 1) ÷ 2
+            p = lid
+            while p <= n_pairs
+                @inbounds begin
+                    if ti < tj
+                        ia = (p - 1) ÷ nj + 1
+                        jb = (p - 1) - (ia - 1) * nj + 1
+                        dx   = shared_xj[jb]               - shared_xi[ia]
+                        dy   = shared_xj[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
+                        du_x = shared_uj[jb]               - shared_ui[ia]
+                        du_y = shared_uj[SF_GPU_TILE + jb] - shared_ui[SF_GPU_TILE + ia]
+                    else
+                        ia, jb = _pair_from_linear(p, ni)
+                        dx   = shared_xi[jb]               - shared_xi[ia]
+                        dy   = shared_xi[SF_GPU_TILE + jb] - shared_xi[SF_GPU_TILE + ia]
+                        du_x = shared_ui[jb]               - shared_ui[ia]
+                        du_y = shared_ui[SF_GPU_TILE + jb] - shared_ui[SF_GPU_TILE + ia]
+                    end
+                    dist = sqrt(dx * dx + dy * dy)
+                    dbin = _gpu_digitize_linear(
                         dist, first_edge, last_edge, inv_step, offset, step_val, N_bins,
                     )
-                    if 1 <= bin < N_bins
-                        r̂ = dX / dist
-                        du = U2 - U1
-                        du_L = r̂[1] * du[1] + r̂[2] * du[2]
-                        du_T = r̂[2] * du[1] - r̂[1] * du[2]
-                        du_L2 = du_L * du_L
-                        du_T2 = du_T * du_T
-                        @atomic output_sums[1, bin, b] += du_L2 + du_T2
-                        @atomic output_sums[2, bin, b] += du_L2
-                        @atomic output_sums[3, bin, b] += du_T2
-                        @atomic output_sums[4, bin, b] += du_L * (du_L2 + du_T2)
-                        @atomic output_sums[5, bin, b] += du_L * du_L2
-                         output_sums[6, bin, b] += du_L * du_T2
-                        for t in 1:SF_GPU_SINGLE_PASS_N
-                            @atomic output_counts[t, bin, b] += UInt32(1)
+                    if 1 <= dbin < N_bins
+                        rx = dx / dist
+                        ry = dy / dist
+                        du_L     = rx * du_x + ry * du_y
+                        du_L2    = du_L * du_L
+                        du_norm2 = du_x * du_x + du_y * du_y
+                        du_T2    = du_norm2 - du_L2
+                        v1 = du_norm2
+                        v2 = du_L2
+                        v3 = du_T2
+                        v4 = du_L * du_norm2
+                        v5 = du_L * du_L2
+                        v6 = du_L * du_T2
+                        @inbounds for t in 1:SF_GPU_SINGLE_PASS_N
+                            val_t = t == 1 ? v1 : t == 2 ? v2 : t == 3 ? v3 : t == 4 ? v4 : t == 5 ? v5 : v6
+                            vbin = _gpu_digitize_value_plan(val_t, val_plan, t, n_val + 1)
+                            if 1 <= vbin <= n_val
+                                @atomic output_sums[t, dbin, vbin, b] += val_t
+                                @atomic output_counts[t, dbin, vbin, b] += UInt32(1)
+                            end
                         end
                     end
                 end

--- a/ext/gpu/launch.jl
+++ b/ext/gpu/launch.jl
@@ -1412,6 +1412,67 @@ function _launch_single_pass_2d!(
 end
 # Production batch launch drivers — fixed-x and varying-x.
 # Included from StructureFunctionsGPUExt.jl after BatchTiledKernels.jl.
+#
+# Fixed-x launch invariant (do not regress):
+# - `ndrange = n_tile_blocks * workgroup_size` only — never multiply by `cld(B, strip_w)`.
+# - Host strip loop over `BATCH_USMEM_STRIP_W` (16) via `_batch_fixed_x_usmem_priv!`.
+# - `KA.CPU`: serial merge; other backends: grouped merge. Same kernel on both.
+# - Varying-x routes use `(tile, auxiliary)` grid scaling (`ndrange * B`), not host strips.
+
+function _launch_batch_fixed_x_sf!(
+    backend::KA.CPU,
+    sums_dev,
+    counts_dev,
+    x_dev,
+    u_dev,
+    sf_type,
+    N::Int,
+    B::Int,
+    lbe::LinearBinEdges{FT};
+    workspace::Union{GPUBatchWorkspace{FT}, Nothing} = nothing,
+) where {FT}
+    n_bins = length(lbe.edges)
+    NB = n_bins - 1
+    NB > SF_GPU_MAX_BINS &&
+        error("batch tiled128 supports at most $SF_GPU_MAX_BINS bins (got NB=$NB)")
+    n_tiles, n_tile_blocks, ws, ndrange = _batch_tiled_launch_params(N)
+    n_priv = _batch_usmem_n_priv(n_tile_blocks)
+    fe, le, is_, off, sv = lbe.first_edge, lbe.last_edge, lbe.inv_step, lbe.offset, lbe.step_val
+    kernel! = _batch_fixed_x_sf_kernel(backend, ws)
+    merge_sums! = _batch_merge_usmem_sums!(backend, ws)
+    merge_cnts! = _batch_merge_usmem_cnts!(backend, ws)
+    partial_sums = KA.zeros(backend, FT, NB, BATCH_USMEM_STRIP_W, n_priv)
+    partial_cnts = KA.zeros(backend, UInt32, NB, n_priv)
+    b_base = 1
+    while b_base <= B
+        bw = min(BATCH_USMEM_STRIP_W, B - b_base + 1)
+        fill!(partial_sums, zero(FT))
+        fill!(partial_cnts, zero(UInt32))
+        kernel!(
+            partial_sums, partial_cnts, x_dev, u_dev, sf_type,
+            N, n_bins, NB, b_base, bw, fe, le, is_, off, sv,
+            n_tiles, n_tile_blocks, ws;
+            ndrange = ndrange,
+        )
+        merge_sums!(
+            @view(sums_dev[:, b_base:b_base + bw - 1]), partial_sums,
+            NB, bw, n_priv, NB * bw;
+            ndrange = NB * bw,
+        )
+        if b_base == 1
+            merge_cnts!(
+                @view(counts_dev[:, 1]), partial_cnts, NB, n_priv, NB;
+                ndrange = NB,
+            )
+        end
+        b_base += bw
+    end
+    if B > 1
+        counts_dev[:, 2:end] .= @view counts_dev[:, 1]
+    end
+    KA.synchronize(backend)
+    return nothing
+end
 
 function _launch_batch_fixed_x_sf!(
     backend::KA.Backend,
@@ -1430,15 +1491,18 @@ function _launch_batch_fixed_x_sf!(
     NB > SF_GPU_MAX_BINS &&
         error("batch tiled128 supports at most $SF_GPU_MAX_BINS bins (got NB=$NB)")
     n_tiles, n_tile_blocks, ws, ndrange = _batch_tiled_launch_params(N)
+    n_priv = _batch_usmem_n_priv(n_tile_blocks)
     fe, le, is_, off, sv = lbe.first_edge, lbe.last_edge, lbe.inv_step, lbe.offset, lbe.step_val
-    kernel! = _batch_fixed_x_usmem_priv!(backend, ws)
-    merge_sums! = _batch_merge_usmem_sums!(backend, ws)
-    merge_cnts! = _batch_merge_usmem_cnts!(backend, ws)
-    partial_sums = KA.zeros(backend, FT, NB, BATCH_USMEM_STRIP_W, n_tile_blocks)
-    partial_cnts = KA.zeros(backend, UInt32, NB, n_tile_blocks)
+    kernel! = _batch_fixed_x_sf_kernel(backend, ws)
+    merge_sums! = _batch_merge_usmem_sums_grouped!(backend, ws)
+    merge_cnts! = _batch_merge_usmem_cnts_grouped!(backend, ws)
+    partial_sums = KA.zeros(backend, FT, NB, BATCH_USMEM_STRIP_W, n_priv)
+    partial_cnts = KA.zeros(backend, UInt32, NB, n_priv)
     b_base = 1
     while b_base <= B
         bw = min(BATCH_USMEM_STRIP_W, B - b_base + 1)
+        fill!(partial_sums, zero(FT))
+        fill!(partial_cnts, zero(UInt32))
         kernel!(
             partial_sums, partial_cnts, x_dev, u_dev, sf_type,
             N, n_bins, NB, b_base, bw, fe, le, is_, off, sv,
@@ -1447,13 +1511,13 @@ function _launch_batch_fixed_x_sf!(
         )
         merge_sums!(
             @view(sums_dev[:, b_base:b_base + bw - 1]), partial_sums,
-            NB, bw, n_tile_blocks, NB * bw;
-            ndrange = NB * bw,
+            NB, bw, n_priv, ws;
+            ndrange = NB * bw * ws,
         )
         if b_base == 1
             merge_cnts!(
-                @view(counts_dev[:, 1]), partial_cnts, NB, n_tile_blocks, NB;
-                ndrange = NB,
+                @view(counts_dev[:, 1]), partial_cnts, NB, n_priv, ws;
+                ndrange = NB * ws,
             )
         end
         b_base += bw
@@ -1466,7 +1530,7 @@ function _launch_batch_fixed_x_sf!(
 end
 
 function _launch_batch_fixed_x_sp1d!(
-    backend::KA.Backend,
+    backend::KA.CPU,
     sums_dev,
     counts_dev,
     x_dev,
@@ -1489,6 +1553,8 @@ function _launch_batch_fixed_x_sp1d!(
     b_base = 1
     while b_base <= B
         bw = min(BATCH_SP1D_USMEM_STRIP_W, B - b_base + 1)
+        fill!(partial_sums, zero(FT))
+        fill!(partial_cnts, zero(UInt32))
         kernel!(
             partial_sums, partial_cnts, x_dev, u_dev,
             N, n_bins, NB, b_base, bw, fe, le, is_, off, sv,
@@ -1504,6 +1570,58 @@ function _launch_batch_fixed_x_sp1d!(
             merge_cnts!(
                 @view(counts_dev[:, :, 1]), partial_cnts, NB, n_tile_blocks, SF_GPU_SINGLE_PASS_N * NB;
                 ndrange = SF_GPU_SINGLE_PASS_N * NB,
+            )
+        end
+        b_base += bw
+    end
+    if B > 1
+        @views counts_dev[:, :, 2:end] .= counts_dev[:, :, 1:1]
+    end
+    KA.synchronize(backend)
+    return nothing
+end
+
+function _launch_batch_fixed_x_sp1d!(
+    backend::KA.Backend,
+    sums_dev,
+    counts_dev,
+    x_dev,
+    u_dev,
+    N::Int,
+    B::Int,
+    lbe::LinearBinEdges{FT};
+) where {FT}
+    n_bins = length(lbe.edges)
+    NB = n_bins - 1
+    NB > SF_GPU_MAX_BINS &&
+        error("batch SP1D tiled128 supports at most $SF_GPU_MAX_BINS bins (got NB=$NB)")
+    n_tiles, n_tile_blocks, ws, ndrange = _batch_tiled_launch_params(N)
+    fe, le, is_, off, sv = lbe.first_edge, lbe.last_edge, lbe.inv_step, lbe.offset, lbe.step_val
+    kernel! = _batch_fixed_x_sp1d_usmem_priv!(backend, ws)
+    merge_sums! = _batch_merge_sp1d_sums_grouped!(backend, ws)
+    merge_cnts! = _batch_merge_sp1d_cnts_grouped!(backend, ws)
+    partial_sums = KA.zeros(backend, FT, SF_GPU_SINGLE_PASS_N, NB, BATCH_SP1D_USMEM_STRIP_W, n_tile_blocks)
+    partial_cnts = KA.zeros(backend, UInt32, SF_GPU_SINGLE_PASS_N, NB, n_tile_blocks)
+    b_base = 1
+    while b_base <= B
+        bw = min(BATCH_SP1D_USMEM_STRIP_W, B - b_base + 1)
+        fill!(partial_sums, zero(FT))
+        fill!(partial_cnts, zero(UInt32))
+        kernel!(
+            partial_sums, partial_cnts, x_dev, u_dev,
+            N, n_bins, NB, b_base, bw, fe, le, is_, off, sv,
+            n_tiles, n_tile_blocks, ws;
+            ndrange = ndrange,
+        )
+        merge_sums!(
+            @view(sums_dev[:, :, b_base:b_base + bw - 1]), partial_sums,
+            NB, bw, n_tile_blocks, ws;
+            ndrange = SF_GPU_SINGLE_PASS_N * NB * bw * ws,
+        )
+        if b_base == 1
+            merge_cnts!(
+                @view(counts_dev[:, :, 1]), partial_cnts, NB, n_tile_blocks, ws;
+                ndrange = SF_GPU_SINGLE_PASS_N * NB * ws,
             )
         end
         b_base += bw
@@ -1535,7 +1653,7 @@ function _launch_batch_varying_x_sf!(
         sums_dev, counts_dev, x_dev, u_dev, sf_type,
         N, n_bins, NB, fe, le, is_, off, sv,
         n_tiles, n_tile_blocks, ws, B;
-        ndrange = ndrange,
+        ndrange = ndrange * B,
     )
     KA.synchronize(backend)
     return nothing
@@ -1560,13 +1678,12 @@ function _launch_batch_varying_x_sp1d!(
         sums_dev, counts_dev, x_dev, u_dev,
         N, n_bins, NB, fe, le, is_, off, sv,
         n_tiles, n_tile_blocks, ws, B;
-        ndrange = ndrange,
+        ndrange = ndrange * B,
     )
     KA.synchronize(backend)
     return nothing
 end
 
-"""Fixed-x SP2D batch: inner `b` in pair loop via varying-x-style kernel with shared `x`."""
 function _launch_batch_fixed_x_sp2d!(
     backend::KA.Backend,
     sums_dev,
@@ -1580,7 +1697,6 @@ function _launch_batch_fixed_x_sp2d!(
     n_dist::Int,
     n_val::Int,
 ) where {FT}
-    # SP2D fixed-x uses strip_w=1 inner-b in pair loop; delegate to host strip + partitioned path.
     n_bins = length(dist_lbe.edges)
     n_tiles, n_tile_blocks, ws, ndrange = _batch_tiled_launch_params(N)
     fe, le, is_, off, sv = dist_lbe.first_edge, dist_lbe.last_edge, dist_lbe.inv_step,
@@ -1591,6 +1707,8 @@ function _launch_batch_fixed_x_sp2d!(
     b_base = 1
     while b_base <= B
         bw = min(BATCH_USMEM_STRIP_W, B - b_base + 1)
+        fill!(partial, zero(FT))
+        fill!(partial_cnt, zero(UInt32))
         kernel!(
             partial, partial_cnt, x_dev, u_dev,
             N, n_bins, n_dist, n_val, b_base, bw,
@@ -1608,110 +1726,8 @@ function _launch_batch_fixed_x_sp2d!(
     return nothing
 end
 
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueLinearShared,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_linear(
-        x, plan.first, plan.last, plan.inv_step, plan.offset, plan.step, n_edges,
-    )
-end
-
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueLinearCols,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_linear(
-        x,
-        plan.first[col],
-        plan.last[col],
-        plan.inv_step[col],
-        plan.offset[col],
-        plan.step[col],
-        n_edges,
-    )
-end
-
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueInfLinearShared,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_inf_padded_linear(
-        x,
-        plan.first,
-        plan.last,
-        plan.inv_step,
-        plan.offset,
-        plan.step,
-        plan.n_inner_edges,
-        plan.inner_last,
-    )
-end
-
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueInfLinearCols,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_inf_padded_linear(
-        x,
-        plan.first[col],
-        plan.last[col],
-        plan.inv_step[col],
-        plan.offset[col],
-        plan.step[col],
-        plan.n_inner_edges,
-        plan.inner_last[col],
-    )
-end
-
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueLogLinearShared,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_log_spaced(
-        x, plan.first, plan.last, plan.inv_step, plan.offset, plan.step, n_edges,
-    )
-end
-
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueLogLinearCols,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_log_spaced_col(
-        x,
-        plan.first,
-        plan.last,
-        plan.inv_step,
-        plan.offset,
-        plan.step,
-        col,
-        n_edges,
-    )
-end
-
-@inline function _gpu_digitize_value_plan(
-    x,
-    plan::GPUValueVectorCols,
-    col::Int,
-    n_edges::Int,
-)
-    return _gpu_digitize_general_col(x, plan.edges_dev, col, n_edges)
-end
-
-function _merge_batch_sp2d_partial!(
-    backend::KA.Backend,
+@inline function _merge_batch_sp2d_partial!(
+    backend::KA.CPU,
     sums_dev,
     counts_dev,
     partial,
@@ -1725,113 +1741,47 @@ function _merge_batch_sp2d_partial!(
 )
     merge_s! = _batch_merge_sp2d_sums!(backend, ws)
     merge_c! = _batch_merge_sp2d_cnts!(backend, ws)
-    nworkers = SF_GPU_SINGLE_PASS_N * n_dist * n_val * bw
+    n_out = SF_GPU_SINGLE_PASS_N * n_dist * n_val * bw
     merge_s!(
         @view(sums_dev[:, :, :, b_base:(b_base + bw - 1)]), partial,
-        n_dist, n_val, bw, n_tile_blocks, nworkers;
-        ndrange = nworkers,
+        n_dist, n_val, bw, n_tile_blocks, n_out;
+        ndrange = n_out,
     )
     merge_c!(
         @view(counts_dev[:, :, :, b_base:(b_base + bw - 1)]), partial_cnt,
-        n_dist, n_val, bw, n_tile_blocks, nworkers;
-        ndrange = nworkers,
+        n_dist, n_val, bw, n_tile_blocks, n_out;
+        ndrange = n_out,
     )
     return nothing
 end
 
-KA.@kernel function _batch_varying_x_sp2d_fixed_x!(
-    partial_sums,
-    partial_cnts,
-    @Const(x_mat),
-    @Const(u_batch),
-    N_points::Int,
-    N_bins::Int,
+@inline function _merge_batch_sp2d_partial!(
+    backend::KA.Backend,
+    sums_dev,
+    counts_dev,
+    partial,
+    partial_cnt,
     n_dist::Int,
     n_val::Int,
     b_base::Int,
     bw::Int,
-    first_edge::FT,
-    last_edge::FT,
-    inv_step::FT,
-    offset::FT,
-    step_val::FT,
-    val_plan::GPUValueDigitizePlan,
-    n_tiles::Int,
     n_tile_blocks::Int,
-    workgroup_size::Int,
-) where {FT}
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
-    block_id = bid
-    if bid <= n_tile_blocks
-        ti, tj = _tile_from_linear(bid, n_tiles)
-        i0 = (ti - 1) * SF_GPU_TILE + 1
-        j0 = (tj - 1) * SF_GPU_TILE + 1
-        ni = min(SF_GPU_TILE, N_points - i0 + 1)
-        nj = min(SF_GPU_TILE, N_points - j0 + 1)
-        if ni > 0 && nj > 0
-            n_pairs = ti < tj ? ni * nj : ni * (ni - 1) ÷ 2
-            p = lid
-            while p <= n_pairs
-                if ti < tj
-                    ia = (p - 1) ÷ nj + 1
-                    jb = (p - 1) - (ia - 1) * nj + 1
-                    gi = i0 + ia - 1
-                    gj = j0 + jb - 1
-                    X1 = SA.SVector{2, FT}(x_mat[1, gi], x_mat[2, gi])
-                    X2 = SA.SVector{2, FT}(x_mat[1, gj], x_mat[2, gj])
-                    dX = X2 - X1
-                    dist = sqrt(dX[1]^2 + dX[2]^2)
-                    dbin = _gpu_digitize_linear(
-                        dist, first_edge, last_edge, inv_step, offset, step_val, N_bins,
-                    )
-                    pair_ok = 1 <= dbin < N_bins
-                    r̂ = pair_ok ? dX / dist : SA.SVector{2, FT}(zero(FT), zero(FT))
-                else
-                    ia, jb = _pair_from_linear(p, ni)
-                    gi = i0 + ia - 1
-                    gj = i0 + jb - 1
-                    X1 = SA.SVector{2, FT}(x_mat[1, gi], x_mat[2, gi])
-                    X2 = SA.SVector{2, FT}(x_mat[1, gj], x_mat[2, gj])
-                    dX = X2 - X1
-                    dist = sqrt(dX[1]^2 + dX[2]^2)
-                    dbin = _gpu_digitize_linear(
-                        dist, first_edge, last_edge, inv_step, offset, step_val, N_bins,
-                    )
-                    pair_ok = 1 <= dbin < N_bins
-                    r̂ = pair_ok ? dX / dist : SA.SVector{2, FT}(zero(FT), zero(FT))
-                end
-                if pair_ok
-                    @inbounds for col in 1:bw
-                        b = b_base + col - 1
-                        U1 = SA.SVector{2, FT}(u_batch[b, gi, 1], u_batch[b, gi, 2])
-                        U2 = SA.SVector{2, FT}(u_batch[b, gj, 1], u_batch[b, gj, 2])
-                        du = U2 - U1
-                        du_L = r̂[1] * du[1] + r̂[2] * du[2]
-                        du_T = r̂[2] * du[1] - r̂[1] * du[2]
-                        du_L2 = du_L * du_L
-                        du_T2 = du_T * du_T
-                        v1 = du_L2 + du_T2
-                        v2 = du_L2
-                        v3 = du_T2
-                        v4 = du_L * (du_L2 + du_T2)
-                        v5 = du_L * du_L2
-                        v6 = du_L * du_T2
-                        @inbounds for t in 1:SF_GPU_SINGLE_PASS_N
-                            val_t = t == 1 ? v1 : t == 2 ? v2 : t == 3 ? v3 : t == 4 ? v4 : t == 5 ? v5 : v6
-                            vbin = _gpu_digitize_value_plan(val_t, val_plan, t, n_val + 1)
-                            if 1 <= vbin <= n_val
-                                @atomic partial_sums[t, dbin, vbin, col, block_id] += val_t
-                                @atomic partial_cnts[t, dbin, vbin, col, block_id] += UInt32(1)
-                            end
-                        end
-                    end
-                end
-                p += workgroup_size
-            end
-        end
-    end
+    ws::Int,
+)
+    merge_s! = _batch_merge_sp2d_sums_grouped!(backend, ws)
+    merge_c! = _batch_merge_sp2d_cnts_grouped!(backend, ws)
+    n_out = SF_GPU_SINGLE_PASS_N * n_dist * n_val * bw
+    merge_s!(
+        @view(sums_dev[:, :, :, b_base:(b_base + bw - 1)]), partial,
+        n_dist, n_val, bw, n_tile_blocks, ws;
+        ndrange = n_out * ws,
+    )
+    merge_c!(
+        @view(counts_dev[:, :, :, b_base:(b_base + bw - 1)]), partial_cnt,
+        n_dist, n_val, bw, n_tile_blocks, ws;
+        ndrange = n_out * ws,
+    )
+    return nothing
 end
 
 function _launch_batch_varying_x_sp2d!(
@@ -1856,92 +1806,10 @@ function _launch_batch_varying_x_sp2d!(
         sums_dev, counts_dev, x_dev, u_dev,
         N, n_bins, n_dist, n_val, fe, le, is_, off, sv, val_plan,
         n_tiles, n_tile_blocks, ws, B;
-        ndrange = ndrange,
+        ndrange = ndrange * B,
     )
     KA.synchronize(backend)
     return nothing
-end
-
-KA.@kernel function _batch_varying_x_sp2d!(
-    output_sums,
-    output_counts,
-    @Const(x_batch),
-    @Const(u_batch),
-    N_points::Int,
-    N_bins::Int,
-    n_dist::Int,
-    n_val::Int,
-    first_edge::FT,
-    last_edge::FT,
-    inv_step::FT,
-    offset::FT,
-    step_val::FT,
-    val_plan::GPUValueDigitizePlan,
-    n_tiles::Int,
-    n_tile_blocks::Int,
-    workgroup_size::Int,
-    B::Int,
-) where {FT}
-    g = @index(Global, Linear)
-    lid = (g - 1) % workgroup_size + 1
-    bid = (g - 1) ÷ workgroup_size + 1
-    if bid <= n_tile_blocks
-        ti, tj = _tile_from_linear(bid, n_tiles)
-        i0 = (ti - 1) * SF_GPU_TILE + 1
-        j0 = (tj - 1) * SF_GPU_TILE + 1
-        ni = min(SF_GPU_TILE, N_points - i0 + 1)
-        nj = min(SF_GPU_TILE, N_points - j0 + 1)
-        if ni > 0 && nj > 0
-            n_pairs = ti < tj ? ni * nj : ni * (ni - 1) ÷ 2
-            p = lid
-            while p <= n_pairs
-                if ti < tj
-                    ia = (p - 1) ÷ nj + 1
-                    jb = (p - 1) - (ia - 1) * nj + 1
-                    gi = i0 + ia - 1
-                    gj = j0 + jb - 1
-                else
-                    ia, jb = _pair_from_linear(p, ni)
-                    gi = i0 + ia - 1
-                    gj = i0 + jb - 1
-                end
-                @inbounds for b in 1:B
-                    X1 = SA.SVector{2, FT}(x_batch[1, gi, b], x_batch[2, gi, b])
-                    X2 = SA.SVector{2, FT}(x_batch[1, gj, b], x_batch[2, gj, b])
-                    U1 = SA.SVector{2, FT}(u_batch[1, gi, b], u_batch[2, gi, b])
-                    U2 = SA.SVector{2, FT}(u_batch[1, gj, b], u_batch[2, gj, b])
-                    dX = X2 - X1
-                    dist = sqrt(dX[1]^2 + dX[2]^2)
-                    dbin = _gpu_digitize_linear(
-                        dist, first_edge, last_edge, inv_step, offset, step_val, N_bins,
-                    )
-                    if 1 <= dbin < N_bins
-                        r̂ = dX / dist
-                        du = U2 - U1
-                        du_L = r̂[1] * du[1] + r̂[2] * du[2]
-                        du_T = r̂[2] * du[1] - r̂[1] * du[2]
-                        du_L2 = du_L * du_L
-                        du_T2 = du_T * du_T
-                        v1 = du_L2 + du_T2
-                        v2 = du_L2
-                        v3 = du_T2
-                        v4 = du_L * (du_L2 + du_T2)
-                        v5 = du_L * du_L2
-                        v6 = du_L * du_T2
-                        @inbounds for t in 1:SF_GPU_SINGLE_PASS_N
-                            val_t = t == 1 ? v1 : t == 2 ? v2 : t == 3 ? v3 : t == 4 ? v4 : t == 5 ? v5 : v6
-                            vbin = _gpu_digitize_value_plan(val_t, val_plan, t, n_val + 1)
-                            if 1 <= vbin <= n_val
-                                @atomic output_sums[t, dbin, vbin, b] += val_t
-                                @atomic output_counts[t, dbin, vbin, b] += UInt32(1)
-                            end
-                        end
-                    end
-                end
-                p += workgroup_size
-            end
-        end
-    end
 end
 
 function _launch_batch_varying_x_joint2d!(
@@ -1961,14 +1829,28 @@ function _launch_batch_varying_x_joint2d!(
     workgroup_size::Int = 64,
 )
     FT = eltype(sums_dev)
+    dist_bins    = _gpu_normalize_bins(distance_bins)
+    n_dist_edges = _gpu_n_edges(distance_bins)
+    n_val_edges  = _gpu_n_edges(value_bins)
+    val_plan     = _joint2d_build_val_plan(backend, value_bins)
+
+    value_host      = _gpu_host_edge_vector(value_bins)
+    value_edges_dev = KA.allocate(backend, FT, n_val_edges)
+    copyto!(value_edges_dev, value_host)
+
+    out_sums_dev = KA.allocate(backend, FT, n_dist, n_val)
+    out_cnts_dev = KA.allocate(backend, UInt32, n_dist, n_val)
+
     for b in 1:B
-        x_sl = @view x_dev[:, :, b]
-        u_sl = @view u_dev[:, :, b]
-        out_sums_dev, out_cnts_dev = _launch_gpu_joint2d!(
-            sf_type, backend, x_sl, u_sl, distance_bins, value_bins;
-            workgroup_size = workgroup_size,
-            workspace = workspace,
-            synchronize = false,
+        fill!(out_sums_dev, zero(FT))
+        fill!(out_cnts_dev, zero(UInt32))
+        _launch_joint_2d_kernel!(
+            backend, workgroup_size,
+            out_sums_dev, out_cnts_dev,
+            @view(x_dev[:, :, b]), @view(u_dev[:, :, b]),
+            value_edges_dev,
+            sf_type, dist_bins, N, n_dist_edges, n_val_edges;
+            val_plan = val_plan,
         )
         copyto!(@view(sums_dev[:, :, b]), out_sums_dev)
         copyto!(@view(counts_dev[:, :, b]), out_cnts_dev)
@@ -1994,13 +1876,32 @@ function _launch_batch_fixed_x_joint2d!(
     workgroup_size::Int = 64,
 )
     FT = eltype(sums_dev)
+    dist_bins    = _gpu_normalize_bins(distance_bins)
+    n_dist_edges = _gpu_n_edges(distance_bins)
+    n_val_edges  = _gpu_n_edges(value_bins)
+    val_plan     = _joint2d_build_val_plan(backend, value_bins)
+
+    value_host      = _gpu_host_edge_vector(value_bins)
+    value_edges_dev = KA.allocate(backend, FT, n_val_edges)
+    copyto!(value_edges_dev, value_host)
+
+    out_sums_dev = KA.allocate(backend, FT, n_dist, n_val)
+    out_cnts_dev = KA.allocate(backend, UInt32, n_dist, n_val)
+
+    # u_dev layout from _stage_batch_device: (B, N, N_dims)
+    # pre-transpose to (N_dims, N, B) once so each slice @view(u_t[:, :, b]) is (N_dims, N)
+    u_t = permutedims(u_dev, (3, 2, 1))
+
     for b in 1:B
-        u_sl = permutedims(@view(u_dev[b, :, :]), (2, 1))
-        out_sums_dev, out_cnts_dev = _launch_gpu_joint2d!(
-            sf_type, backend, x_dev, u_sl, distance_bins, value_bins;
-            workgroup_size = workgroup_size,
-            workspace = workspace,
-            synchronize = false,
+        fill!(out_sums_dev, zero(FT))
+        fill!(out_cnts_dev, zero(UInt32))
+        _launch_joint_2d_kernel!(
+            backend, workgroup_size,
+            out_sums_dev, out_cnts_dev,
+            x_dev, @view(u_t[:, :, b]),
+            value_edges_dev,
+            sf_type, dist_bins, N, n_dist_edges, n_val_edges;
+            val_plan = val_plan,
         )
         copyto!(@view(sums_dev[:, :, b]), out_sums_dev)
         copyto!(@view(counts_dev[:, :, b]), out_cnts_dev)

--- a/ext/gpu/sf_core.jl
+++ b/ext/gpu/sf_core.jl
@@ -1,0 +1,138 @@
+# =============================================================================
+# Unified parametric GPU kernel core — building blocks
+# See gpu/OPTIMAL_KERNEL_DESIGN.md for the full design rationale.
+#
+# These are the compile-time-specialized primitives shared by the two unified
+# tiled kernels (`sf_tiled_1d!`, `sf_tiled_2d!`). Everything here is `@inline`,
+# allocation-free, and device-safe (validated on the KA.CPU() backend).
+#
+# Conventions
+# -----------
+# * Staged tile layout: dimension `d` of local point `k` lives at
+#   `buf[(d-1)*SF_GPU_TILE + k]` in an `@localmem` buffer (matches the existing
+#   tiled kernels).
+# * Distance digitizers are *isbits* functors (no array fields for linear/log)
+#   so they can be passed directly as kernel arguments and specialize the
+#   digitize at compile time. The bin-edge wrapper structs (LinearBinEdges /
+#   LogBinEdges) are NOT isbits (they hold a Range), hence these lightweight
+#   mirrors built host-side via `_sf_digitizer`.
+# * The shared histogram uses a "lane" axis of width `L` as its fastest index:
+#       hist[((m-1)*NB + (bin-1)) * L + lane]
+#   For the non-fixed-x path `L = R` (replication factor → contention spreading;
+#   replicas are summed at flush). For the fixed-x batch path `L = W` (batch
+#   strip → each lane is a distinct velocity field; NOT summed, scattered to the
+#   B axis at flush). Same accumulate primitive, different flush.
+#   IMPORTANT: we rotate the *lane* (replica) index, never the *bin* index.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Distance digitizers (isbits functors; compile-time dispatched)
+# -----------------------------------------------------------------------------
+
+"""Linear-grid distance digitizer. `n_edges` is the number of bin *edges*
+(so the number of bins is `n_edges - 1`). Returns a bin in `0:n_edges`."""
+struct SFLinearDigitizer{T}
+    first_edge::T
+    last_edge::T
+    inv_step::T
+    offset::T
+    step_val::T
+    n_edges::Int
+end
+
+@inline (d::SFLinearDigitizer{T})(r::T) where {T} =
+    _gpu_digitize_linear(r, d.first_edge, d.last_edge, d.inv_step, d.offset, d.step_val, d.n_edges)
+
+"""Log-grid distance digitizer: `log(r)` then a linear digitize on the log grid
+(matches `LogBinEdges`). Non-positive `r` falls below the first edge (→ 0)."""
+struct SFLogDigitizer{T}
+    first_edge::T
+    last_edge::T
+    inv_step::T
+    offset::T
+    step_val::T
+    n_edges::Int
+end
+
+@inline (d::SFLogDigitizer{T})(r::T) where {T} =
+    r <= zero(T) ? 0 :
+    _gpu_digitize_linear(log(r), d.first_edge, d.last_edge, d.inv_step, d.offset, d.step_val, d.n_edges)
+
+"""General (arbitrary edges) distance digitizer: binary search over a device
+edge vector. `edges` is adapted to the backend alongside the kernel arguments."""
+struct SFGeneralDigitizer{E}
+    edges::E
+    n_edges::Int
+end
+
+@inline (d::SFGeneralDigitizer)(r) = _gpu_digitize_general(r, d.edges, d.n_edges)
+
+# Number of bins (edges - 1) for a digitizer.
+@inline _sf_nbins(d::SFLinearDigitizer) = d.n_edges - 1
+@inline _sf_nbins(d::SFLogDigitizer) = d.n_edges - 1
+@inline _sf_nbins(d::SFGeneralDigitizer) = d.n_edges - 1
+
+# Host-side constructors from the bin-edge wrapper types.
+@inline _sf_digitizer(lbe::LinearBinEdges) =
+    SFLinearDigitizer(lbe.first_edge, lbe.last_edge, lbe.inv_step, lbe.offset, lbe.step_val, length(lbe.edges))
+
+@inline function _sf_digitizer(lbe::LogBinEdges)
+    ll = lbe.log_linear
+    return SFLogDigitizer(ll.first_edge, ll.last_edge, ll.inv_step, ll.offset, ll.step_val, length(lbe.log_edges))
+end
+
+# General edges: caller passes a device array of edges (already on backend).
+@inline _sf_digitizer_general(edges_dev) = SFGeneralDigitizer(edges_dev, length(edges_dev))
+
+# -----------------------------------------------------------------------------
+# Geometry (NDIMS-generic, via StaticArrays — unrolls for D = 2, 3)
+# -----------------------------------------------------------------------------
+
+@inline _sf_dot(a::SA.SVector{2,T}, b::SA.SVector{2,T}) where {T} = a[1] * b[1] + a[2] * b[2]
+@inline _sf_dot(a::SA.SVector{3,T}, b::SA.SVector{3,T}) where {T} = a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+
+"""Load local point `k` (D components) from a staged `@localmem` tile buffer."""
+@inline _sf_load_pt(::Val{2}, buf, k::Int) =
+    @inbounds SA.SVector{2}(buf[k], buf[SF_GPU_TILE + k])
+@inline _sf_load_pt(::Val{3}, buf, k::Int) =
+    @inbounds SA.SVector{3}(buf[k], buf[SF_GPU_TILE + k], buf[2 * SF_GPU_TILE + k])
+
+# -----------------------------------------------------------------------------
+# Moments
+# -----------------------------------------------------------------------------
+
+"""Six single-pass invariants from a velocity difference `dU` and unit vector
+`rhat`. Computes one dot product (`du_L`) and one norm (`du_norm2`); transverse
+follows as `du_norm2 - du_L²` (no second projection)."""
+@inline function _sf_moments6(dU::SA.SVector{D,T}, rhat::SA.SVector{D,T}) where {D,T}
+    du_L = _sf_dot(dU, rhat)
+    du_norm2 = _sf_dot(dU, dU)
+    du_L2 = du_L * du_L
+    du_T2 = du_norm2 - du_L2
+    return (du_norm2, du_L2, du_T2, du_L * du_norm2, du_L * du_L2, du_L * du_T2)
+end
+
+"""Compute the moment tuple for a pair:
+- `Val{6}` → the six single-pass invariants (sf_type ignored).
+- `Val{1}` → the individual SF value, computed by the **authoritative** `sf_type(δu, r̂)`
+  callable from `StructureFunctionTypes` — the single source of truth for the per-type
+  math (basis- and dimension-dependent factors like `1/(D-1)` and the signed `mδu_t`/`n̂`
+  components are handled there, and it is the same code the CPU paths use). Returned as a
+  1-tuple so the accumulate path is uniform with the single-pass case."""
+@inline _sf_moments(::Val{6}, sf_type, dU, rhat) = _sf_moments6(dU, rhat)
+@inline _sf_moments(::Val{1}, sf_type, dU, rhat) = (sf_type(dU, rhat),)
+
+# -----------------------------------------------------------------------------
+# Shared-histogram layout (lane axis = R replicas or W batch strip)
+#
+# A pair's contribution to moment `m`, distance bin `bin`, lane `ℓ` lives at
+#     shared_sums[(m-1)*NB*L + (bin-1)*L + ℓ]      (L = R or W, compile-time)
+#     shared_cnts[(bin-1)*L + ℓ]
+#
+# All looped reads/writes/atomics on these `@localmem` buffers are written
+# INLINE in the kernel bodies, NOT via helper functions. On the CUDA backend a
+# `@localmem` array passed as a function argument and written in a loop fails to
+# compile (GPUCompiler MethodError); inlining matches the proven pattern used by
+# the existing tiled kernels. Single-element loads through a helper are fine
+# (see `_sf_load_pt` / `_sf_load_field`).
+# -----------------------------------------------------------------------------

--- a/ext/gpu/sf_tiled.jl
+++ b/ext/gpu/sf_tiled.jl
@@ -1,0 +1,1004 @@
+# =============================================================================
+# Unified parametric tiled kernels (replace the per-variant 1D/2D kernels).
+# See gpu/OPTIMAL_KERNEL_DESIGN.md. Building blocks in sf_core.jl.
+#
+# sf_tiled_1d_varying!  — non-batch (B=1) and varying-x batch (B>1). One
+#   workgroup per (tile-pair, batch element). Privatized + R-replicated shared
+#   histogram; replicas summed at flush. Covers individual (NMOM=1) and
+#   single-pass (NMOM=6), 2D/3D, linear/log/general bins — all via Val{} params.
+# =============================================================================
+
+KA.@kernel unsafe_indices = true function sf_tiled_1d_varying!(
+    output,                 # (NMOM, NB, B)
+    counts,                 # (NMOM, NB, B)  (count replicated across moment rows)
+    @Const(x),              # (D, N, B)      (non-batch: B = 1)
+    @Const(u),              # (D, N, B)
+    sf_type,
+    digitizer,              # SFLinearDigitizer / SFLogDigitizer / SFGeneralDigitizer
+    N::Int,
+    NB::Int,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    wgsize::Int,
+    B::Int,
+    ::Val{D},
+    ::Val{NMOM},
+    ::Val{R},
+) where {D, NMOM, R}
+    shared_xi = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_xj = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_ui = @localmem eltype(u) (D * SF_GPU_TILE,)
+    shared_uj = @localmem eltype(u) (D * SF_GPU_TILE,)
+    shared_sums = @localmem eltype(output) (NMOM * SF_GPU_MAX_BINS * R,)
+    shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS * R,)
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+
+    # phase 0: zero shared histogram (cooperative). Inlined: looped writes to a
+    # @localmem array must live in the kernel body — passing it to a helper and
+    # writing in a loop fails to compile on this GPU stack.
+    zsum = zero(eltype(output))
+    zi = lid
+    while zi <= NMOM * NB * R
+        @inbounds shared_sums[zi] = zsum
+        zi += wgsize
+    end
+    zc = lid
+    while zc <= NB * R
+        @inbounds shared_cnts[zc] = UInt32(0)
+        zc += wgsize
+    end
+    @synchronize
+
+    # phase 1: stage tile coordinates into shared memory
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds for d in 1:D
+                    shared_xi[(d - 1) * SF_GPU_TILE + k] = x[d, gi, b]
+                    shared_ui[(d - 1) * SF_GPU_TILE + k] = u[d, gi, b]
+                end
+                k += wgsize
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds for d in 1:D
+                        shared_xj[(d - 1) * SF_GPU_TILE + k] = x[d, gj, b]
+                        shared_uj[(d - 1) * SF_GPU_TILE + k] = u[d, gj, b]
+                    end
+                    k += wgsize
+                end
+            end
+        end
+    end
+    @synchronize
+
+    # phase 2: enumerate pairs, accumulate into replicated shared histogram
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            off_diag = ti < tj
+            n_pairs = off_diag ? ni * nj : ni * (ni - 1) ÷ 2
+            lane = ((lid - 1) ÷ 32) % R + 1   # rotate the REPLICA index, never the bin
+            p = lid
+            while p <= n_pairs
+                if off_diag
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xj, jb)
+                    Ui = _sf_load_pt(Val(D), shared_ui, ia)
+                    Uj = _sf_load_pt(Val(D), shared_uj, jb)
+                else
+                    ia, jb = _pair_from_linear(p, ni)
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xi, jb)
+                    Ui = _sf_load_pt(Val(D), shared_ui, ia)
+                    Uj = _sf_load_pt(Val(D), shared_ui, jb)
+                end
+                dX = Xj - Xi
+                dist = sqrt(_sf_dot(dX, dX))
+                bin = digitizer(dist)
+                if 1 <= bin <= NB
+                    rhat = dX / dist
+                    dU = Uj - Ui
+                    moments = _sf_moments(Val(NMOM), sf_type, dU, rhat)
+                    # accumulate into replica `lane` (inline localmem atomics)
+                    abase = (bin - 1) * R + lane
+                    @inbounds for m in 1:NMOM
+                        @atomic shared_sums[(m - 1) * (NB * R) + abase] += moments[m]
+                    end
+                    @inbounds @atomic shared_cnts[abase] += UInt32(1)
+                end
+                p += wgsize
+            end
+        end
+    end
+    @synchronize
+
+    # phase 3: reduce replicas and flush to global output
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        rplane = NB * R
+        cell = lid
+        ncell = NMOM * NB
+        while cell <= ncell
+            m = (cell - 1) % NMOM + 1
+            bin = (cell - 1) ÷ NMOM + 1
+            rbase = (m - 1) * rplane + (bin - 1) * R
+            acc = zero(eltype(output))
+            @inbounds for r in 1:R
+                acc += shared_sums[rbase + r]
+            end
+            @inbounds @atomic output[m, bin, b] += acc
+            cell += wgsize
+        end
+        bcell = lid
+        while bcell <= NB
+            cbase = (bcell - 1) * R
+            ctot = UInt32(0)
+            @inbounds for r in 1:R
+                ctot += shared_cnts[cbase + r]
+            end
+            if ctot != UInt32(0)
+                @inbounds for m in 1:NMOM
+                    @atomic counts[m, bcell, b] += ctot
+                end
+            end
+            bcell += wgsize
+        end
+    end
+end
+
+# -----------------------------------------------------------------------------
+# Launch wrappers
+# -----------------------------------------------------------------------------
+
+"""Replication factor R for the 1D varying-x shared histogram, from the A100 R/W
+sweep (gpu/benchmark_results/tune_*.md). Regime-dependent:
+- Individual SF (NMOM=1): tiny histogram, extreme per-bin contention → R=2 helps
+  small NB (NB16: R2≈77 vs R1≈70); larger NB are flat. Beyond R=2 hurts (occupancy).
+- Single-pass (NMOM=6): 6× bigger histogram → R=1 (R≥2 blows occupancy: R1≈35,
+  R4≈22, R8≈11). So R=1."""
+@inline _sf_tiled_1d_replication(::Type{FT}, D::Int, NMOM::Int) where {FT} = NMOM == 1 ? 2 : 1
+
+"""Launch sf_tiled_1d_varying! for non-batch (B=1) or varying-x (B>1).
+`x_dev`, `u_dev` are (D, N, B); `out_dev`, `cnt_dev` are (NMOM, NB, B)."""
+function _launch_sf_tiled_1d_varying!(
+    backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer,
+    N::Int, NB::Int, B::Int, ::Val{D}, ::Val{NMOM};
+    R::Int = _sf_tiled_1d_replication(eltype(out_dev), D, NMOM),
+) where {D, NMOM}
+    n_tiles = cld(N, SF_GPU_TILE)
+    n_tile_blocks = n_tiles * (n_tiles + 1) ÷ 2
+    ws = SF_GPU_TILED_WS
+    ndrange = n_tile_blocks * ws * B
+    kernel! = sf_tiled_1d_varying!(backend, ws)
+    if R == 16
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer, N, NB,
+                n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(16); ndrange = ndrange)
+    elseif R == 8
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer, N, NB,
+                n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(8); ndrange = ndrange)
+    elseif R == 4
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer, N, NB,
+                n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(4); ndrange = ndrange)
+    elseif R == 2
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer, N, NB,
+                n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(2); ndrange = ndrange)
+    else
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer, N, NB,
+                n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(1); ndrange = ndrange)
+    end
+    return nothing
+end
+
+# =============================================================================
+# sf_tiled_1d_fixed! — fixed-x batch: shared geometry x, B velocity fields u.
+# Geometry (dist, r̂, bin) is computed ONCE per pair and amortized across a strip
+# of W fields (W is the privatization axis). Sums use lane = field (scatter to B
+# at flush, NOT summed). Counts are field-independent, so the W lanes are used as
+# contention replicas (one atomic/pair) and summed → broadcast to the strip's B.
+# Host launches ⌈B/W⌉ strips (cheap, async, single sync); geometry is recomputed
+# per strip (W-fold reuse — moments dominate, so this is near-optimal).
+# W-strip shared index for field w, dim d, local point k: laid out
+# `((w-1)*D + (d-1))*SF_GPU_TILE + k` (written inline at the use sites to match
+# the proven inline-index staging pattern that compiles on CUDA).
+# =============================================================================
+
+KA.@kernel unsafe_indices = true function sf_tiled_1d_fixed!(
+    output,                 # (NMOM, NB, B)
+    counts,                 # (NMOM, NB, B)
+    @Const(x),              # (D, N)        shared geometry
+    @Const(u),              # (D, N, B)     velocity fields
+    sf_type,
+    digitizer,
+    N::Int,
+    NB::Int,
+    b_base::Int,            # first batch element of this strip
+    bw::Int,                # this strip's width (≤ W)
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    wgsize::Int,
+    ::Val{D},
+    ::Val{NMOM},
+    ::Val{W},
+) where {D, NMOM, W}
+    shared_xi = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_xj = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_ui = @localmem eltype(u) (W * D * SF_GPU_TILE,)
+    shared_uj = @localmem eltype(u) (W * D * SF_GPU_TILE,)
+    shared_sums = @localmem eltype(output) (NMOM * SF_GPU_MAX_BINS * W,)
+    shared_cnts = @localmem UInt32 (SF_GPU_MAX_BINS * W,)
+
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
+
+    # phase 0: zero shared histogram inline (looped localmem writes must be in
+    # the kernel body, not via a helper, on this GPU stack)
+    zsum = zero(eltype(output))
+    zi = lid
+    while zi <= NMOM * NB * W
+        @inbounds shared_sums[zi] = zsum
+        zi += wgsize
+    end
+    zc = lid
+    while zc <= NB * W
+        @inbounds shared_cnts[zc] = UInt32(0)
+        zc += wgsize
+    end
+    @synchronize
+
+    # phase 1: stage x (once) and u (bw fields) into shared memory
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds for d in 1:D
+                    shared_xi[(d - 1) * SF_GPU_TILE + k] = x[d, gi]
+                end
+                @inbounds for w in 1:bw
+                    bb = b_base + w - 1
+                    for d in 1:D
+                        shared_ui[((w - 1) * D + (d - 1)) * SF_GPU_TILE + k] = u[d, gi, bb]
+                    end
+                end
+                k += wgsize
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds for d in 1:D
+                        shared_xj[(d - 1) * SF_GPU_TILE + k] = x[d, gj]
+                    end
+                    @inbounds for w in 1:bw
+                        bb = b_base + w - 1
+                        for d in 1:D
+                            shared_uj[((w - 1) * D + (d - 1)) * SF_GPU_TILE + k] = u[d, gj, bb]
+                        end
+                    end
+                    k += wgsize
+                end
+            end
+        end
+    end
+    @synchronize
+
+    # phase 2: geometry once per pair, accumulate W fields
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            off_diag = ti < tj
+            n_pairs = off_diag ? ni * nj : ni * (ni - 1) ÷ 2
+            cnt_lane = ((lid - 1) ÷ 32) % W + 1
+            p = lid
+            while p <= n_pairs
+                if off_diag
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xj, jb)
+                else
+                    ia, jb = _pair_from_linear(p, ni)
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xi, jb)
+                end
+                dX = Xj - Xi
+                dist = sqrt(_sf_dot(dX, dX))
+                bin = digitizer(dist)
+                if 1 <= bin <= NB
+                    rhat = dX / dist
+                    @inbounds for w in 1:bw
+                        Ui = off_diag ?
+                            _sf_load_field(Val(D), shared_ui, w, ia) :
+                            _sf_load_field(Val(D), shared_ui, w, ia)
+                        Uj = off_diag ?
+                            _sf_load_field(Val(D), shared_uj, w, jb) :
+                            _sf_load_field(Val(D), shared_ui, w, jb)
+                        dU = Uj - Ui
+                        moments = _sf_moments(Val(NMOM), sf_type, dU, rhat)
+                        # sums: lane = field w (scatter, not summed)
+                        base = (bin - 1) * W + w
+                        plane = NB * W
+                        for m in 1:NMOM
+                            @atomic shared_sums[(m - 1) * plane + base] += moments[m]
+                        end
+                    end
+                    # counts: field-independent → one atomic into a contention replica
+                    @atomic shared_cnts[(bin - 1) * W + cnt_lane] += UInt32(1)
+                end
+                p += wgsize
+            end
+        end
+    end
+    @synchronize
+
+    # phase 3: flush. sums scatter per field; counts sum replicas → broadcast.
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
+    if bid <= n_tile_blocks
+        plane = NB * W
+        cell = lid
+        ncell = NMOM * NB
+        while cell <= ncell
+            m = (cell - 1) % NMOM + 1
+            bin = (cell - 1) ÷ NMOM + 1
+            base = (m - 1) * plane + (bin - 1) * W
+            @inbounds for w in 1:bw
+                @atomic output[m, bin, b_base + w - 1] += shared_sums[base + w]
+            end
+            cell += wgsize
+        end
+        bcell = lid
+        while bcell <= NB
+            total = UInt32(0)
+            cbase = (bcell - 1) * W
+            @inbounds for r in 1:W
+                total += shared_cnts[cbase + r]
+            end
+            if total != UInt32(0)
+                @inbounds for w in 1:bw, m in 1:NMOM
+                    @atomic counts[m, bcell, b_base + w - 1] += total
+                end
+            end
+            bcell += wgsize
+        end
+    end
+end
+
+"""Load field `w`'s D-vector for local point `k` from a strip-staged u buffer."""
+@inline _sf_load_field(::Val{2}, buf, w::Int, k::Int) =
+    @inbounds SA.SVector{2}(buf[(w - 1) * 2 * SF_GPU_TILE + k], buf[((w - 1) * 2 + 1) * SF_GPU_TILE + k])
+@inline _sf_load_field(::Val{3}, buf, w::Int, k::Int) =
+    @inbounds SA.SVector{3}(buf[(w - 1) * 3 * SF_GPU_TILE + k], buf[((w - 1) * 3 + 1) * SF_GPU_TILE + k], buf[((w - 1) * 3 + 2) * SF_GPU_TILE + k])
+
+"""Strip width W for fixed-x 1D, from the A100 R/W sweep. Regime-dependent:
+- Individual SF (NMOM=1): a 4-wide strip amortizes the (relatively expensive)
+  geometry over 4 fields → W=4 is the clear peak (~99–107 Gpairs/s vs 64 at W=1,
+  across NB=16/50/128); this also makes fixed-x beat varying-x as it should.
+- Single-pass (NMOM=6): 6× histogram → striping blows occupancy → W=1 (W1≈40,
+  W2≈34, W4≈22). See gpu/benchmark_results/tune_*.md."""
+@inline _sf_tiled_1d_fixed_strip(::Type{FT}, D::Int, NMOM::Int) where {FT} = NMOM == 1 ? 4 : 1
+
+"""Launch fixed-x batch 1D over ⌈B/W⌉ strips. x_dev=(D,N), u_dev=(D,N,B),
+out_dev/cnt_dev=(NMOM,NB,B). Single synchronize after all strips."""
+function _launch_sf_tiled_1d_fixed!(
+    backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer,
+    N::Int, NB::Int, B::Int, ::Val{D}, ::Val{NMOM};
+    W::Int = _sf_tiled_1d_fixed_strip(eltype(out_dev), D, NMOM),
+) where {D, NMOM}
+    n_tiles = cld(N, SF_GPU_TILE)
+    n_tile_blocks = n_tiles * (n_tiles + 1) ÷ 2
+    ws = SF_GPU_TILED_WS
+    ndrange = n_tile_blocks * ws
+    launch = (Wv) -> begin
+        kernel! = sf_tiled_1d_fixed!(backend, ws)
+        b_base = 1
+        while b_base <= B
+            bw = min(Wv, B - b_base + 1)
+            kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, digitizer, N, NB,
+                    b_base, bw, n_tiles, n_tile_blocks, ws, Val(D), Val(NMOM), Val(Wv);
+                    ndrange = ndrange)
+            b_base += bw
+        end
+    end
+    W == 16 ? launch(16) : W == 8 ? launch(8) : W == 4 ? launch(4) : W == 2 ? launch(2) : launch(1)
+    return nothing
+end
+
+# =============================================================================
+# 2D joint-histogram tiled kernels (distance × value). Output is
+# (NMOM, n_dist, n_val[, B]) — far too large for shared memory (6·128·128·4 ≈
+# 393 KB), so accumulation is DIRECT GLOBAL ATOMICS. Spread over up to ~16K
+# cells the per-cell contention is low (fast on Volta+). x/u tiles are still
+# staged in shared memory for data reuse. NMOM=1 → joint2d (individual),
+# NMOM=6 → single-pass 2D. Replaces the naive per-cell (N,N) kernel + host
+# for-b loop that caused the batch 17s regression.
+# =============================================================================
+
+KA.@kernel unsafe_indices = true function sf_tiled_2d_varying!(
+    output,                 # (NMOM, n_dist, n_val, B)
+    counts,                 # (NMOM, n_dist, n_val, B)
+    @Const(x),              # (D, N, B)
+    @Const(u),              # (D, N, B)
+    sf_type,
+    dist_digitizer,
+    val_plan,
+    N::Int,
+    n_dist::Int,
+    n_val::Int,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    wgsize::Int,
+    B::Int,
+    ::Val{D},
+    ::Val{NMOM},
+) where {D, NMOM}
+    shared_xi = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_xj = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_ui = @localmem eltype(u) (D * SF_GPU_TILE,)
+    shared_uj = @localmem eltype(u) (D * SF_GPU_TILE,)
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+
+    # phase 1: stage tile coordinates
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds for d in 1:D
+                    shared_xi[(d - 1) * SF_GPU_TILE + k] = x[d, gi, b]
+                    shared_ui[(d - 1) * SF_GPU_TILE + k] = u[d, gi, b]
+                end
+                k += wgsize
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds for d in 1:D
+                        shared_xj[(d - 1) * SF_GPU_TILE + k] = x[d, gj, b]
+                        shared_uj[(d - 1) * SF_GPU_TILE + k] = u[d, gj, b]
+                    end
+                    k += wgsize
+                end
+            end
+        end
+    end
+    @synchronize
+
+    # phase 2: pair loop, direct global atomics into the 2D histogram
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            off_diag = ti < tj
+            n_pairs = off_diag ? ni * nj : ni * (ni - 1) ÷ 2
+            p = lid
+            while p <= n_pairs
+                if off_diag
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xj, jb)
+                    Ui = _sf_load_pt(Val(D), shared_ui, ia)
+                    Uj = _sf_load_pt(Val(D), shared_uj, jb)
+                else
+                    ia, jb = _pair_from_linear(p, ni)
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xi, jb)
+                    Ui = _sf_load_pt(Val(D), shared_ui, ia)
+                    Uj = _sf_load_pt(Val(D), shared_ui, jb)
+                end
+                dX = Xj - Xi
+                dist = sqrt(_sf_dot(dX, dX))
+                dbin = dist_digitizer(dist)
+                if 1 <= dbin <= n_dist
+                    rhat = dX / dist
+                    dU = Uj - Ui
+                    moments = _sf_moments(Val(NMOM), sf_type, dU, rhat)
+                    @inbounds for m in 1:NMOM
+                        vbin = _gpu_digitize_value_plan(moments[m], val_plan, m, n_val + 1)
+                        if 1 <= vbin <= n_val
+                            @atomic output[m, dbin, vbin, b] += moments[m]
+                            @atomic counts[m, dbin, vbin, b] += UInt32(1)
+                        end
+                    end
+                end
+                p += wgsize
+            end
+        end
+    end
+end
+
+"""Launch sf_tiled_2d_varying! for non-batch (B=1) or varying-x (B>1).
+x_dev,u_dev=(D,N,B); out_dev,cnt_dev=(NMOM,n_dist,n_val,B)."""
+function _launch_sf_tiled_2d_varying!(
+    backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+    N::Int, n_dist::Int, n_val::Int, B::Int, ::Val{D}, ::Val{NMOM},
+) where {D, NMOM}
+    n_tiles = cld(N, SF_GPU_TILE)
+    n_tile_blocks = n_tiles * (n_tiles + 1) ÷ 2
+    ws = SF_GPU_TILED_WS
+    kernel! = sf_tiled_2d_varying!(backend, ws)
+    kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+            N, n_dist, n_val, n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM);
+            ndrange = n_tile_blocks * ws * B)
+    return nothing
+end
+
+# ----- 2D with a SHARED-memory histogram (small bin counts), fixed or varying --
+# When NMOM·n_dist·n_val fits in shared memory, accumulate into a block-local
+# histogram (fast shared atomics) and flush once — same idea as the 1D kernel and
+# the existing tiled joint2d kernel, which beats direct global atomics by ~7×.
+# NCELLS = n_dist·n_val is a compile-time Val so @localmem can be sized to it
+# (keeps occupancy high — no over-allocation). One block per (tile-pair, b).
+# `x` is always 3D: (D,N,B) for varying-x, (D,N,1) for fixed-x (FIXED_X picks the
+# x slice; u is always (D,N,B)). Host uses this only when it fits.
+KA.@kernel unsafe_indices = true function sf_tiled_2d_shared!(
+    output,                 # (NMOM, n_dist, n_val, B)
+    counts,                 # (NMOM, n_dist, n_val, B)
+    @Const(x),              # (D, N, B) varying  /  (D, N, 1) fixed
+    @Const(u),              # (D, N, B)
+    sf_type,
+    dist_digitizer,
+    val_plan,
+    N::Int,
+    n_dist::Int,
+    n_val::Int,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    wgsize::Int,
+    B::Int,
+    ::Val{D},
+    ::Val{NMOM},
+    ::Val{NCELLS},
+    ::Val{FIXED_X},
+) where {D, NMOM, NCELLS, FIXED_X}
+    shared_xi = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_xj = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_ui = @localmem eltype(u) (D * SF_GPU_TILE,)
+    shared_uj = @localmem eltype(u) (D * SF_GPU_TILE,)
+    shared_sums = @localmem eltype(output) (NMOM * NCELLS,)
+    shared_cnts = @localmem UInt32 (NMOM * NCELLS,)
+
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+
+    # phase 0: zero shared histogram (inline)
+    zsum = zero(eltype(output))
+    zi = lid
+    while zi <= NMOM * NCELLS
+        @inbounds shared_sums[zi] = zsum
+        @inbounds shared_cnts[zi] = UInt32(0)
+        zi += wgsize
+    end
+    @synchronize
+
+    # phase 1: stage tile coordinates
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            xb = FIXED_X ? 1 : b
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds for d in 1:D
+                    shared_xi[(d - 1) * SF_GPU_TILE + k] = x[d, gi, xb]
+                    shared_ui[(d - 1) * SF_GPU_TILE + k] = u[d, gi, b]
+                end
+                k += wgsize
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds for d in 1:D
+                        shared_xj[(d - 1) * SF_GPU_TILE + k] = x[d, gj, xb]
+                        shared_uj[(d - 1) * SF_GPU_TILE + k] = u[d, gj, b]
+                    end
+                    k += wgsize
+                end
+            end
+        end
+    end
+    @synchronize
+
+    # phase 2: pair loop, accumulate into the shared 2D histogram
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            off_diag = ti < tj
+            n_pairs = off_diag ? ni * nj : ni * (ni - 1) ÷ 2
+            p = lid
+            while p <= n_pairs
+                if off_diag
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xj, jb)
+                    Ui = _sf_load_pt(Val(D), shared_ui, ia)
+                    Uj = _sf_load_pt(Val(D), shared_uj, jb)
+                else
+                    ia, jb = _pair_from_linear(p, ni)
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xi, jb)
+                    Ui = _sf_load_pt(Val(D), shared_ui, ia)
+                    Uj = _sf_load_pt(Val(D), shared_ui, jb)
+                end
+                dX = Xj - Xi
+                dist = sqrt(_sf_dot(dX, dX))
+                dbin = dist_digitizer(dist)
+                if 1 <= dbin <= n_dist
+                    rhat = dX / dist
+                    dU = Uj - Ui
+                    moments = _sf_moments(Val(NMOM), sf_type, dU, rhat)
+                    @inbounds for m in 1:NMOM
+                        vbin = _gpu_digitize_value_plan(moments[m], val_plan, m, n_val + 1)
+                        if 1 <= vbin <= n_val
+                            cell = (m - 1) * NCELLS + (dbin - 1) * n_val + vbin
+                            @atomic shared_sums[cell] += moments[m]
+                            @atomic shared_cnts[cell] += UInt32(1)
+                        end
+                    end
+                end
+                p += wgsize
+            end
+        end
+    end
+    @synchronize
+
+    # phase 3: flush shared histogram to global output
+    lid = @index(Local, Linear)
+    launch_block = @index(Group, Linear)
+    bid = (launch_block - 1) % n_tile_blocks + 1
+    b = (launch_block - 1) ÷ n_tile_blocks + 1
+    if bid <= n_tile_blocks && b <= B
+        cell = lid
+        while cell <= NMOM * NCELLS
+            s = shared_sums[cell]
+            c = shared_cnts[cell]
+            if c != UInt32(0)
+                m = (cell - 1) ÷ NCELLS + 1
+                lc = (cell - 1) % NCELLS
+                dbin = lc ÷ n_val + 1
+                vbin = lc % n_val + 1
+                @inbounds @atomic output[m, dbin, vbin, b] += s
+                @inbounds @atomic counts[m, dbin, vbin, b] += c
+            end
+            cell += wgsize
+        end
+    end
+end
+
+"""Does a shared NMOM×n_dist×n_val histogram (sums+counts) fit in ~44 KB
+alongside the 4 staged coordinate tiles? If so the shared kernel is much faster
+than direct global atomics."""
+@inline function _sf_2d_shared_fits(::Type{FT}, D::Int, NMOM::Int, n_dist::Int, n_val::Int) where {FT}
+    hist = NMOM * n_dist * n_val * (sizeof(FT) + sizeof(UInt32))
+    staging = 4 * D * SF_GPU_TILE * sizeof(FT)
+    return hist + staging <= 44 * 1024
+end
+
+"""Launch the shared-histogram 2D kernel (caller guarantees the histogram fits).
+`x_dev` is (D,N,B) for varying-x or (D,N,1) for fixed-x; `u_dev` is (D,N,B)."""
+function _launch_sf_tiled_2d_shared!(
+    backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+    N::Int, n_dist::Int, n_val::Int, B::Int, ::Val{D}, ::Val{NMOM}, fixed_x::Bool,
+) where {D, NMOM}
+    n_tiles = cld(N, SF_GPU_TILE)
+    n_tile_blocks = n_tiles * (n_tiles + 1) ÷ 2
+    ws = SF_GPU_TILED_WS
+    ndrange = n_tile_blocks * ws * B
+    kernel! = sf_tiled_2d_shared!(backend, ws)
+    if fixed_x
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+                N, n_dist, n_val, n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(n_dist * n_val), Val(true);
+                ndrange = ndrange)
+    else
+        kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+                N, n_dist, n_val, n_tiles, n_tile_blocks, ws, B, Val(D), Val(NMOM), Val(n_dist * n_val), Val(false);
+                ndrange = ndrange)
+    end
+    return nothing
+end
+
+# ----- fixed-x 2D: geometry once, W-field strip, direct global atomics -------
+
+KA.@kernel unsafe_indices = true function sf_tiled_2d_fixed!(
+    output,                 # (NMOM, n_dist, n_val, B)
+    counts,                 # (NMOM, n_dist, n_val, B)
+    @Const(x),              # (D, N)
+    @Const(u),              # (D, N, B)
+    sf_type,
+    dist_digitizer,
+    val_plan,
+    N::Int,
+    n_dist::Int,
+    n_val::Int,
+    b_base::Int,
+    bw::Int,
+    n_tiles::Int,
+    n_tile_blocks::Int,
+    wgsize::Int,
+    ::Val{D},
+    ::Val{NMOM},
+    ::Val{W},
+) where {D, NMOM, W}
+    shared_xi = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_xj = @localmem eltype(x) (D * SF_GPU_TILE,)
+    shared_ui = @localmem eltype(u) (W * D * SF_GPU_TILE,)
+    shared_uj = @localmem eltype(u) (W * D * SF_GPU_TILE,)
+
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
+
+    # phase 1: stage x once, u for bw fields
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            k = lid
+            while k <= ni
+                gi = i0 + k - 1
+                @inbounds for d in 1:D
+                    shared_xi[(d - 1) * SF_GPU_TILE + k] = x[d, gi]
+                end
+                @inbounds for w in 1:bw
+                    bb = b_base + w - 1
+                    for d in 1:D
+                        shared_ui[((w - 1) * D + (d - 1)) * SF_GPU_TILE + k] = u[d, gi, bb]
+                    end
+                end
+                k += wgsize
+            end
+            if ti < tj
+                k = lid
+                while k <= nj
+                    gj = j0 + k - 1
+                    @inbounds for d in 1:D
+                        shared_xj[(d - 1) * SF_GPU_TILE + k] = x[d, gj]
+                    end
+                    @inbounds for w in 1:bw
+                        bb = b_base + w - 1
+                        for d in 1:D
+                            shared_uj[((w - 1) * D + (d - 1)) * SF_GPU_TILE + k] = u[d, gj, bb]
+                        end
+                    end
+                    k += wgsize
+                end
+            end
+        end
+    end
+    @synchronize
+
+    # phase 2: geometry once per pair, loop bw fields, direct global atomics
+    lid = @index(Local, Linear)
+    bid = @index(Group, Linear)
+    if bid <= n_tile_blocks
+        ti, tj = _tile_from_linear(bid, n_tiles)
+        i0 = (ti - 1) * SF_GPU_TILE + 1
+        j0 = (tj - 1) * SF_GPU_TILE + 1
+        ni = min(SF_GPU_TILE, N - i0 + 1)
+        nj = min(SF_GPU_TILE, N - j0 + 1)
+        if ni > 0 && nj > 0
+            off_diag = ti < tj
+            n_pairs = off_diag ? ni * nj : ni * (ni - 1) ÷ 2
+            p = lid
+            while p <= n_pairs
+                if off_diag
+                    ia = (p - 1) ÷ nj + 1
+                    jb = (p - 1) - (ia - 1) * nj + 1
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xj, jb)
+                else
+                    ia, jb = _pair_from_linear(p, ni)
+                    Xi = _sf_load_pt(Val(D), shared_xi, ia)
+                    Xj = _sf_load_pt(Val(D), shared_xi, jb)
+                end
+                dX = Xj - Xi
+                dist = sqrt(_sf_dot(dX, dX))
+                dbin = dist_digitizer(dist)
+                if 1 <= dbin <= n_dist
+                    rhat = dX / dist
+                    @inbounds for w in 1:bw
+                        Ui = _sf_load_field(Val(D), shared_ui, w, ia)
+                        Uj = off_diag ? _sf_load_field(Val(D), shared_uj, w, jb) :
+                                        _sf_load_field(Val(D), shared_ui, w, jb)
+                        dU = Uj - Ui
+                        moments = _sf_moments(Val(NMOM), sf_type, dU, rhat)
+                        bb = b_base + w - 1
+                        for m in 1:NMOM
+                            vbin = _gpu_digitize_value_plan(moments[m], val_plan, m, n_val + 1)
+                            if 1 <= vbin <= n_val
+                                @atomic output[m, dbin, vbin, bb] += moments[m]
+                                @atomic counts[m, dbin, vbin, bb] += UInt32(1)
+                            end
+                        end
+                    end
+                end
+                p += wgsize
+            end
+        end
+    end
+end
+
+"""Strip width W for fixed-x 2D (only x/u staged in shared; no shared hist)."""
+@inline function _sf_tiled_2d_fixed_strip(::Type{FT}, D::Int) where {FT}
+    budget = 46 * 1024
+    x_bytes = 2 * D * SF_GPU_TILE * sizeof(FT)
+    per_w = 2 * D * SF_GPU_TILE * sizeof(FT)
+    w = (budget - x_bytes) ÷ per_w
+    w = max(1, min(w, 16))
+    w >= 16 ? 16 : w >= 8 ? 8 : w >= 4 ? 4 : w >= 2 ? 2 : 1
+end
+
+"""Launch fixed-x batch 2D over ⌈B/W⌉ strips. x_dev=(D,N), u_dev=(D,N,B)."""
+function _launch_sf_tiled_2d_fixed!(
+    backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+    N::Int, n_dist::Int, n_val::Int, B::Int, ::Val{D}, ::Val{NMOM};
+    W::Int = _sf_tiled_2d_fixed_strip(eltype(out_dev), D),
+) where {D, NMOM}
+    n_tiles = cld(N, SF_GPU_TILE)
+    n_tile_blocks = n_tiles * (n_tiles + 1) ÷ 2
+    ws = SF_GPU_TILED_WS
+    ndrange = n_tile_blocks * ws
+    launch = (Wv) -> begin
+        kernel! = sf_tiled_2d_fixed!(backend, ws)
+        b_base = 1
+        while b_base <= B
+            bw = min(Wv, B - b_base + 1)
+            kernel!(out_dev, cnt_dev, x_dev, u_dev, sf_type, dist_digitizer, val_plan,
+                    N, n_dist, n_val, b_base, bw, n_tiles, n_tile_blocks, ws,
+                    Val(D), Val(NMOM), Val(Wv); ndrange = ndrange)
+            b_base += bw
+        end
+    end
+    W == 16 ? launch(16) : W == 8 ? launch(8) : W == 4 ? launch(4) : W == 2 ? launch(2) : launch(1)
+    return nothing
+end
+
+# -----------------------------------------------------------------------------
+# Dispatch helpers used when rewiring the public API onto the unified kernels.
+# -----------------------------------------------------------------------------
+
+"""Build a distance digitizer from whatever distance-bins form the public API
+passes (typed edges, range, uniform vector → linear; non-uniform vector →
+general device-array binary search). Supersedes the old `linear-only` batch
+restriction."""
+function _sf_batch_dist_digitizer(backend, distance_bins)
+    distance_bins isa LinearBinEdges && return _sf_digitizer(distance_bins)
+    distance_bins isa LogBinEdges && return _sf_digitizer(distance_bins)
+    distance_bins isa BinEdges && return _sf_batch_dist_digitizer(backend, distance_bins.edges)
+    distance_bins isa AbstractRange && return _sf_digitizer(LinearBinEdges(distance_bins))
+    if distance_bins isa AbstractVector
+        n = length(distance_bins)
+        if n >= 2
+            f = first(distance_bins); l = last(distance_bins)
+            r = range(f, l; length = n)
+            if all(i -> isapprox(distance_bins[i], r[i]; atol = 1e-6), 1:n)
+                return _sf_digitizer(LinearBinEdges(r))
+            end
+        end
+        edges_dev = KA.adapt(backend, collect(distance_bins))
+        return _sf_digitizer_general(edges_dev)
+    end
+    error("unsupported distance_bins type $(typeof(distance_bins))")
+end
+
+"""Dispatch a 2D batch launch on runtime D ∈ {2,3} into the Val-specialized launchers."""
+function _sf_launch_2d_batch!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, ddig, vplan,
+                              N, n_dist, n_val, B, D::Int, ::Val{NMOM}, fixed_x::Bool) where {NMOM}
+    # CUDA fast path (N-body broadcast + dynamic-shared privatized histogram,
+    # TILE=1024) when StructureFunctionsCUDAExt is active and it fits the device.
+    SFC.gpu_fast_launch_2d_batch!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, ddig, vplan,
+                                  N, n_dist, n_val, B, D, NMOM, fixed_x) && return nothing
+    # Prefer the shared-histogram kernel (fixed or varying) when the histogram
+    # fits (~7× faster than direct global atomics); fall back to global for large
+    # bin counts that don't fit in shared memory.
+    use_shared = _sf_2d_shared_fits(eltype(out_dev), D, NMOM, n_dist, n_val)
+    go(Dv) =
+        use_shared ?
+            _launch_sf_tiled_2d_shared!(backend, out_dev, cnt_dev,
+                (fixed_x ? reshape(x_dev, size(x_dev, 1), size(x_dev, 2), 1) : x_dev),
+                u_dev, sf_type, ddig, vplan, N, n_dist, n_val, B, Dv, Val(NMOM), fixed_x) :
+        fixed_x ?
+            _launch_sf_tiled_2d_fixed!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, ddig, vplan, N, n_dist, n_val, B, Dv, Val(NMOM)) :
+            _launch_sf_tiled_2d_varying!(backend, out_dev, cnt_dev, x_dev, u_dev, sf_type, ddig, vplan, N, n_dist, n_val, B, Dv, Val(NMOM))
+    D == 2 ? go(Val(2)) : D == 3 ? go(Val(3)) : error("GPU 2D batch requires D ∈ {2,3} (got $D)")
+    return nothing
+end
+
+"""Dispatch a 1D batch launch on runtime D ∈ {2,3} into the Val-specialized launchers.
+`out`/`cnt` are (NMOM, NB, B); x_dev/u_dev are (D,N,B) varying or x=(D,N),u=(D,N,B) fixed."""
+function _sf_launch_1d_batch!(backend, out, cnt, x_dev, u_dev, sf_type, dig,
+                              N, NB, B, D::Int, ::Val{NMOM}, fixed_x::Bool) where {NMOM}
+    # CUDA fast path (N-body broadcast + static-shared privatized histogram,
+    # TILE=256) when StructureFunctionsCUDAExt is active and NB fits.
+    SFC.gpu_fast_launch_1d_batch!(backend, out, cnt, x_dev, u_dev, sf_type, dig,
+                                  N, NB, B, D, NMOM, fixed_x) && return nothing
+    go(Dv) = fixed_x ?
+        _launch_sf_tiled_1d_fixed!(backend, out, cnt, x_dev, u_dev, sf_type, dig, N, NB, B, Dv, Val(NMOM)) :
+        _launch_sf_tiled_1d_varying!(backend, out, cnt, x_dev, u_dev, sf_type, dig, N, NB, B, Dv, Val(NMOM))
+    D == 2 ? go(Val(2)) : D == 3 ? go(Val(3)) : error("GPU 1D batch requires D ∈ {2,3} (got $D)")
+    return nothing
+end

--- a/ext/gpu/value_digitize_plans.jl
+++ b/ext/gpu/value_digitize_plans.jl
@@ -58,10 +58,20 @@ struct GPUValueLogLinearCols{T}
     step::SA.SVector{SF_GPU_SINGLE_PASS_N, T}
 end
 
-"""Plain `Vector` value columns: binary search on `(n_edges, 6)` edge matrix."""
-struct GPUValueVectorCols{T}
-    edges_dev
+"""Plain `Vector` value columns: binary search on `(n_edges, 6)` edge matrix.
+`edges_dev` is typed (param `E`) so the struct is isbits-after-adapt and can be
+passed to a GPU kernel; the `adapt_structure` rule below converts the device
+edge matrix to its in-kernel form when KA adapts kernel arguments."""
+struct GPUValueVectorCols{T, E}
+    edges_dev::E
 end
+
+# Keep the existing 1-type-param constructor calls working (E inferred).
+GPUValueVectorCols{T}(edges_dev::E) where {T, E} = GPUValueVectorCols{T, E}(edges_dev)
+
+# Make KA's argument adaptation recurse into the device edge matrix.
+KA.Adapt.adapt_structure(to, p::GPUValueVectorCols{T}) where {T} =
+    GPUValueVectorCols{T}(KA.Adapt.adapt(to, p.edges_dev))
 
 const GPUValueDigitizePlan = Union{
     GPUValueLinearShared,
@@ -288,3 +298,106 @@ function _validate_gpu_value_bins!(value_bins, n_val::Int)
     end
     return nothing
 end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueLinearShared,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_linear(
+        x, plan.first, plan.last, plan.inv_step, plan.offset, plan.step, n_edges,
+    )
+end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueLinearCols,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_linear(
+        x,
+        plan.first[col],
+        plan.last[col],
+        plan.inv_step[col],
+        plan.offset[col],
+        plan.step[col],
+        n_edges,
+    )
+end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueInfLinearShared,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_inf_padded_linear(
+        x,
+        plan.first,
+        plan.last,
+        plan.inv_step,
+        plan.offset,
+        plan.step,
+        plan.n_inner_edges,
+        plan.inner_last,
+    )
+end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueInfLinearCols,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_inf_padded_linear(
+        x,
+        plan.first[col],
+        plan.last[col],
+        plan.inv_step[col],
+        plan.offset[col],
+        plan.step[col],
+        plan.n_inner_edges,
+        plan.inner_last[col],
+    )
+end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueLogLinearShared,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_log_spaced(
+        x, plan.first, plan.last, plan.inv_step, plan.offset, plan.step, n_edges,
+    )
+end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueLogLinearCols,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_log_spaced_col(
+        x,
+        plan.first,
+        plan.last,
+        plan.inv_step,
+        plan.offset,
+        plan.step,
+        col,
+        n_edges,
+    )
+end
+
+@inline function _gpu_digitize_value_plan(
+    x,
+    plan::GPUValueVectorCols,
+    col::Int,
+    n_edges::Int,
+)
+    return _gpu_digitize_general_col(x, plan.edges_dev, col, n_edges)
+end
+

--- a/ext/gpu/workspace.jl
+++ b/ext/gpu/workspace.jl
@@ -412,6 +412,36 @@ function GPUBatchWorkspace(
     )
 end
 
+"""Device bytes for block-private partial `(NB, B_chunk, n_tile_blocks)` sums."""
+function _batch_fixed_x_chunk_partial_bytes(N_points::Int, B_chunk::Int, NB::Int, ::Type{FT}) where {FT}
+    _, n_tile_blocks, _, _ = _batch_tiled_launch_params(N_points)
+    return n_tile_blocks * NB * B_chunk * sizeof(FT)
+end
+
+"""Split `1:B` into chunks whose `(NB, B_chunk, n_tile_blocks)` partial fits `max_partial_bytes`."""
+function batch_fixed_x_chunk_ranges(
+    B::Int,
+    max_partial_bytes::Int,
+    N_points::Int,
+    NB::Int,
+    ::Type{FT},
+) where {FT}
+    if max_partial_bytes <= 0 || B <= 0
+        return [1:B]
+    end
+    per_b = _batch_fixed_x_chunk_partial_bytes(N_points, 1, NB, FT)
+    per_b <= 0 && return [1:B]
+    chunk = max(1, max_partial_bytes ÷ per_b)
+    ranges = UnitRange{Int}[]
+    b0 = 1
+    while b0 <= B
+        b1 = min(B, b0 + chunk - 1)
+        push!(ranges, b0:b1)
+        b0 = b1 + 1
+    end
+    return ranges
+end
+
 """VRAM bytes for block-private partial `(2·NB, B, n_tile_blocks)` sums + counts."""
 function estimate_batch_priv_bytes(N_points::Int, B::Int, NB::Int, ::Type{FT}) where {FT}
     n_tiles = cld(N_points, SF_GPU_TILE)

--- a/gpu/GPU_2d_joint_sf_plan.md
+++ b/gpu/GPU_2d_joint_sf_plan.md
@@ -1,127 +1,49 @@
-# GPU 2D joint structure functions — implementation plan
+# GPU Joint 2D Route Notes
 
-**Status:** Phase 1–3 done including **tiled128 block-local fast path** for 2D joint SF
-(when `n_dist × n_val ≤ SF_GPU_MAX_2D_HIST`). Larger histograms use `(N,N)` global-atomics fallback.
-In-place GPU API remains optional follow-up.
-
-**Scope:** `calculate_structure_function(sf_type, x_mat, u_mat, distance_bins, value_bins; backend=GPUBackend(...))` for dense `(2, N_points)` matrix inputs.
-
-**Implemented separately:**
-
-- `calculate_structure_functions_single_pass_2d` / `calculate_structure_functions_single_pass_2d!` on `GPUBackend` — eight `(distance × value)` histograms via **HTP-EJ** tiled128 (`ext/TiledSinglePass2DPrivKernels.jl`). On-chip modes flush like joint 2D; `:direct` uses priv+merge. See [`gpu/SP2D_HTP_EJ.md`](SP2D_HTP_EJ.md).
-
-**Out of scope (unless requested):**
-
-- Tuple `(x_vecs..., u_vecs...)` on GPU (matrix only).
-- In-place `calculate_structure_function!(..., value_bins)` on GPU.
-- GPU in-place `calculate_structure_functions_single_pass!` (1D eight-tensor path).
-- `N_dims = 3` for 2D joint histogram API (1D tiled SF still supports 2D/3D coordinates).
-
-**Count types:** device histogram buffers are always `UInt32` (atomics + shared memory).
-`count_eltype` (default `UInt32`) selects the host array type after download only.
-
----
-
-## 1. CPU reference (must match)
-
-Serial inner loop (`calculate_structure_function_2d_i!`):
-
-1. Upper triangle only: pairs with `j > i`.
-2. `distance = metric(x_i, x_j)` → `dist_bin = digitize(distance, distance_bins)`.
-3. If `1 ≤ dist_bin < length(distance_bins)` (interior distance bin):
-   - `val = sf_type(u_j - u_i, r̂)` → `val_bin = digitize(val, value_bins)`.
-   - If `1 ≤ val_bin < length(value_bins)`: `sums_2d[dist_bin, val_bin] += val`, `counts_2d[dist_bin, val_bin] += 1`.
-
-Result type: `StructureFunction2D` with flat `distance_bins` and `value_bins` edge vectors.
-
----
-
-## 2. API wiring
-
-| Entry | Status |
-|-------|--------|
-| `_dispatch_execution_backend(::GPUBackend, ..., value_bins)` | → `gpu_calculate_structure_function_2d(...)` |
-| `gpu_calculate_structure_function_2d` | Implemented in `StructureFunctionsGPUExt.jl` |
-| `_dispatch_execution_backend!(::GPUBackend, ..., value_bins)` | Still throws — Phase 4 |
-| `_dispatch_single_pass` / `_dispatch_single_pass_2d` (allocating) | Implemented |
-| `_dispatch_single_pass!` on GPU | Still throws — optional |
-
----
-
-## 3. Kernel design (as shipped)
-
-**Default (eligible bins):** tiled128 block-local flat histogram (`TiledStructureFunction2DKernels.jl`) —
-same tile schedule as 1D SF; accumulate in `@localmem`, flush once per cell per block.
-
-**Fallback:** `(N_points, N_points)` global-atomic pair kernels when
-`n_dist > SF_GPU_MAX_BINS`, `n_val > SF_GPU_MAX_BINS`, or
-`n_dist * n_val > SF_GPU_MAX_2D_HIST` (4096).
-
-### Shared-memory compile width (2025)
-
-Default: exact `n_dist × n_val` `@localmem` cells (best occupancy when `NB2 ≪ 4096`).
-Override on [`GPUSFWorkspace`](@ref):
+This note documents the current distance × value GPU route for a single structure-function operator.
+The public entry point is:
 
 ```julia
-GPUSFWorkspace(backend, dist_bins, val_bins)  # exact NB2 (default)
-
-GPUSFWorkspace(backend, dist_bins, val_bins;
-    joint2d_compile_cells = joint2d_smem_max())  # legacy 4096, one kernel for any grid
-
-GPUSFWorkspace(backend, dist_bins, val_bins;
-    joint2d_compile_cells = joint2d_smem_align256(n_dist, n_val))
+calculate_structure_function(sf_type, x, u, distance_bins, value_bins; backend=GPUBackend(...))
 ```
 
-Helpers: `joint2d_smem_max`, `joint2d_smem_exact`, `joint2d_smem_align256` (return `Int`).
-Kernels are `@eval`'d on first use per `(dist_route, compile_cells)` and cached on the workspace.
-CPU parity: `test/test_gpu_joint2d_smem.jl`.
+Supported inputs follow the package shape contract: `x` and `u` are arrays with spatial or velocity
+dimension in `size(_, 1)` and point count in `size(_, 2)`. The joint 2D histogram route currently
+supports `D == 2`; use the 1D distance-bin GPU route for `D == 3` scalar outputs.
 
----
+## Routes
 
-## 4. Implementation phases
+Eligible bin grids use tiled upper-triangle pair traversal with block-local histograms and a final
+global merge. Larger grids use explicit global-atomic kernels. The route is selected from bin shape,
+not by silently falling back to CPU.
 
-### Phase 1 — Minimal correct path ✅
+Device count histograms are `UInt32`. The public `count_eltype` keyword controls the downloaded host
+count array type only.
 
-- [x] `gpu_calculate_structure_function_2d` host driver + dispatch hook in GPU ext
-- [x] `(N,N)` kernels: `N_dims=2`, linear / log / general distance routes
-- [x] KA.CPU parity vs `SerialBackend` (`test/test_gpu_parity.jl`, `test/test_2d_binning.jl`)
+## Workspace
 
-### Phase 2 — Bin coverage ✅ (partial)
+Use `GPUSFWorkspace(backend, distance_bins, value_bins; kind=:joint2d)` to reuse device buffers and
+compiled route state across repeated calls. The workspace also accepts `joint2d_compile_cells` for
+shared-memory compile width tuning:
 
-- [x] Log / general distance bins
-- [x] General value bins (device edge vector)
-- [ ] `N_dims = 3` for joint SF API (deferred; 1D GPU tiled path covers 3D coords)
-- [x] CUDA parity sections in `gpu/test_cuda_parity.jl`
+```julia
+GPUSFWorkspace(backend, dist_bins, value_bins; kind=:joint2d)
+GPUSFWorkspace(backend, dist_bins, value_bins; kind=:joint2d,
+               joint2d_compile_cells=joint2d_smem_max())
+```
 
-### Phase 3 — CUDA + performance (mostly done)
+Helpers:
 
-- [x] `gpu/test_cuda_parity.jl` — 1D linear/log, joint 2D ×2, single_pass_2d
-- [x] Tiled128 2D joint kernels (`TiledStructureFunction2DKernels.jl`) + automatic routing
-- [x] HTP-EJ SP2D on-chip flush (no priv+merge for `:shared`/`:typeplane`); A100 gate `sp2d < 8×joint` on 20×22 and 50×52 — see `gpu/benchmark_2d_grid_scaling.jl`, `gpu/SP2D_HTP_EJ.md`
-- [ ] Further SP2D perf (typeplane sync, digitize fusion) — documented in `SP2D_HTP_EJ.md` § future work
-- [ ] Profile on A100; tune `workgroup_size` / tile size
-- [x] Document max bin grid + `count_eltype` policy in GPU ext docstrings
+- `joint2d_smem_max()`
+- `joint2d_smem_exact(n_dist, n_val)`
+- `joint2d_smem_align256(n_dist, n_val)`
 
-### Phase 4 — In-place API (optional)
+## Tests
 
-- [ ] `gpu_calculate_structure_function_2d!` + `_dispatch_execution_backend!` for `GPUBackend`
-- [ ] GPU `_dispatch_single_pass!`
-- [ ] Tests mirroring `test_inplace.jl` 2D cases
+CPU-runnable parity and routing tests live in:
 
----
+- `test/test_gpu_parity.jl`
+- `test/test_2d_binning.jl`
+- `test/test_gpu_joint2d_smem.jl`
 
-## 5. Tests
-
-| Test | Status |
-|------|--------|
-| KA.CPU vs Serial (1D + 2D joint + single_pass_2d) | In `test/runtests.jl` |
-| CUDA vs CPU on SLURM | `gpu/test_cuda_parity.jl` (manual / cluster) |
-| Max bins exceeded | `ArgumentError` on 1D tiled path (`SF_GPU_MAX_BINS`) |
-
----
-
-## 6. Non-goals / policy
-
-- **No fallback** to `SerialBackend` when user passes `GPUBackend`.
-- **No tuple** `(x, u)` on GPU.
-- Device histograms **`UInt32`**; **`count_eltype`** is host-only.
+CUDA parity lives in `gpu/test_cuda_parity.jl` and is run manually inside a Slurm GPU allocation.

--- a/gpu/OPTIMAL_KERNEL_DESIGN.md
+++ b/gpu/OPTIMAL_KERNEL_DESIGN.md
@@ -1,0 +1,272 @@
+# Optimal GPU Kernel Design for StructureFunctions.jl
+
+Authoritative design derived from first principles + literature (June 2026). Supersedes
+the ad-hoc per-variant kernels. Goal: blazing-fast CPU+GPU for 1D/2D binning, individual
+and single-pass (6 invariants), and batched inputs — with **one source of truth per kernel
+family** so we never refactor this again.
+
+## 1. The computation
+
+For every unordered pair `(i,j)`, `i<j`, of `N` points with positions `x` and velocities
+`u` in `D` dimensions:
+
+```
+dx   = x_j - x_i              # separation
+r    = |dx|;  r̂ = dx / r      # distance + unit vector
+du   = u_j - u_i              # velocity difference
+du_L = du · r̂                 # longitudinal
+du_norm2 = du·du ;  du_L2 = du_L²
+du_T2    = du_norm2 - du_L2   # transverse² (no second dot product needed)
+```
+
+Accumulate into a distance bin `b = digitize(r)`:
+- **individual** (1 moment, chosen `sf_type`)
+- **single-pass** (6 invariants): `{du_norm2, du_L2, du_T2, du_L·du_norm2, du_L·du_L2, du_L·du_T2}`
+
+Output histograms:
+- **1D**: `(NMOM, NB)` — distance bins only. `NB ≤ 128`.
+- **2D joint**: `(NMOM, n_dist, n_val)` — distance × value bins.
+
+**Batched** adds a trailing `B` axis:
+- **fixed-x**: geometry `x` shared across all `B`; only `u` varies → compute `(r,r̂,bin)` ONCE, reuse across `B`.
+- **varying-x**: both `x` and `u` vary → `B` independent problems.
+
+## 2. Why the old design failed
+
+- **~47 hand-written kernels** (`{2d,3d}×{linear,log,general}`, 39 `@eval`'d sp2d variants,
+  13 batch merge kernels). Fixes must be copy-pasted N× and drift. This is the root cause.
+- **Batch joint2d** ran a naive per-cell `(N,N)` global-atomic kernel inside a host
+  `for b in 1:B` loop → the ~17s (vs 2–5s target) regression.
+- **No replication / contention mitigation** was ever correctly implemented. A prior
+  "staggering" attempt offset the *bin index* (corrupts the histogram) instead of the
+  *replica index*.
+
+## 3. Optimal algorithm (literature-grounded)
+
+Workload = **N-body tiling fused with a histogram scatter**. Per-pair compute is heavy
+(~20–40 FLOPs), so data-reuse tiling matters and atomics are relatively cheap per pair.
+
+1. **Tile** points into blocks of `p` (=128) staged in shared memory; one workgroup per
+   **upper-triangular tile-pair** (off-diagonal: full `p²`; diagonal: `j>i` loop). Optional
+   **tile-level distance cull** skips tile-pairs whose minimum separation exceeds the max
+   bin edge — cell-list-like speedup when bins are cutoff-limited, free otherwise.
+2. **1D histogram → privatize + replicate in shared memory.** Hist is tiny
+   (6×128×4B ≈ 3KB), so keep `R` independent replicas to cut atomic contention:
+   ```
+   replica = warp_id % R                      # rotate the REPLICA, never the bin
+   slot    = (moment*NB + bin)*R + replica
+   ```
+   Replicas are full independent histograms, summed order-independently at flush — no
+   un-stagger. Pad the layout so consecutive lanes hit distinct banks. Flush = one global
+   atomic per `(moment,bin)`. **No separate merge kernel.**
+3. **Batch fixed-x → the strip width `W` is the privatization axis.** Compute geometry once
+   per pair; accumulate `W` velocity fields into a `(moment×bin×W)` shared histogram; flush
+   once. `W` competes with `R` for the 48KB budget. Eliminates the old global-partial+merge.
+4. **2D joint histogram (≈393KB) → direct global atomics.** Too big for shared, but spread
+   over ~16K cells → low per-cell contention; on Volta+ this is fastest. (Optional shared
+   fast-path when `NMOM·n_dist·n_val` actually fits; value-axis tiling only if profiling
+   shows L2 contention.)
+5. **Reductions** use warp-shuffle butterfly, never serial `lid==1` loops.
+
+## 4. The kernel set (collapse ~47 → ~3)
+
+All specialized at compile time via `Val{}` type parameters (zero runtime cost, confirmed
+for KernelAbstractions). Production pins tuned `R`,`W` to one value each → small
+specialization matrix (`2 dims × 3 digitizers × 2 nmom × 2 fixed ≈ 24`).
+
+### `sf_tiled_1d!`
+Params: `Val{NDIMS}`, digitizer functor `D` (linear/log/general; `general` carries edges),
+`Val{NMOM}` (1 or 6), `Val{R}`, `Val{W}` (1 = non-batch/varying-x), `Val{FIXED_X}`.
+Covers: non-batch individual + sp1d, fixed-x batch, varying-x batch. No merge kernel.
+
+### `sf_tiled_2d!`
+Params: `Val{NDIMS}`, dist digitizer, value digitizer, `Val{NMOM}`, `Val{W}`,
+`Val{FIXED_X}`, `Val{SHARED}`. Direct global atomics into `(NMOM,n_dist,n_val[,B])`.
+Covers: non-batch joint2d + sp2d, both batch variants (fixes the 17s path with a single
+fused launch — no host `for b` loop, no naive per-cell kernel).
+
+### `reduce_partials!`
+One parametric warp-shuffle/tree reduction. Replaces all 15 merge kernels. Used only where
+global partials genuinely remain (rare given privatization).
+
+## 5. Memory layouts (locked — hard to change later)
+
+- `x`, `u`: `(NDIMS, N)` non-batch; `(NDIMS, N, B)` batch. **Fixed-x `u` staged WITHOUT** the
+  old double-`permutedims` to `(B,N,NDIMS)`; stage so the `W`-strip load is coalesced.
+- Outputs: 1D `(NMOM, NB[, B])`; 2D `(NMOM, n_dist, n_val[, B])`. `NMOM=1` collapses cleanly.
+- Buffers allocated once; reset with `fill!` (async), not `KA.zeros`, inside any loop.
+  Async launches, a single `KA.synchronize` at the end.
+
+## 6. Empirical tuning (Slurm hand-off — never run GPU in chat)
+
+Sweep on representative **non-uniform** turbulence fields and lock constants:
+`R`, tile `p∈{64,128,256}`, `W`-vs-`R`, block size / occupancy, warp-aggregation on/off,
+2D shared-vs-global threshold. A benchmark harness exposes these via the `Val{}` params; the
+user runs it in a Slurm allocation and returns numbers.
+
+## 7. Execution phases (tests stay green; correctness validated on `KA.CPU()`)
+
+- **P0** Cleanup stray/experimental files.
+- **P1** Building blocks: digitizers, geometry, moments, privatized+replicated accumulator, reduction.
+- **P2** `sf_tiled_1d!` + migrate the 4 1D paths; parity-test vs current on CPU.
+- **P3** `sf_tiled_2d!` + migrate the 4 2D paths (fixes 17s); parity-test.
+- **P4** Unify reductions; delete the 15 merge kernels.
+- **P5** Delete the ~40 dead kernels; collapse dispatch.
+- **P6** Slurm benchmark harness; tune; lock constants.
+- **P7** CPU/threaded batch verification.
+
+## 8. References
+
+KernelAbstractions.jl docs (localmem/synchronize/atomix/performance examples); Gómez-Luna
+et al. 2013 (histogram replication R-factor); NVIDIA Maxwell shared-atomics & warp-aggregated
+atomics blogs; GPU Gems 3 Ch.31 (N-body tiling); CADISHI arXiv:1808.01478 (parallel pair
+distance histograms, diagonal/off-diagonal split); Jia et al. Volta/Turing microbenchmarks
+(atomic latency under contention).
+
+---
+
+# FINAL SETTLED DESIGN (measured on A100, 2026-06-23)
+
+After exhaustive prototyping+measurement (see `gpu/benchmark_results/`), the kernel
+design is locked. Metric is **billion atom-pairs/s (bapps)** at saturation (CADISHI
+ref ~495 for *pure distance*; our SF does more per pair). All numbers N=20000, A100.
+
+## Structure (the decisive finding)
+**N-body broadcast loop**, NOT thread-owns-a-pair. Each thread owns its point `i`
+in registers and loops `j` over the staged tile so all lanes read the *same*
+`shared[j]` each step (broadcast, no bank conflict, NO per-pair `_pair_from_linear`
+sqrt). This was a 1.36–2.0× win for 1D and recovers/beats the old code.
+- Tile = block: `TILE` points per tile, `TILE` threads/block, thread `t` owns tile point `t`.
+- Upper-triangular tile-pairs. Off-diagonal: thread loops `j=1..nj` (broadcast).
+  Diagonal: thread loops `j=lid+1..ni` (loses broadcast, but minority of tiles).
+- Histogram: per-block **privatized** (shared) + atomic-merge to global at block end.
+
+## Per-regime parameters (all measured)
+| regime | structure | TILE | histogram |
+|--------|-----------|------|-----------|
+| 1D individual (NMOM=1) | N-body | 256 | shared `(NB)`, static |
+| 1D single-pass (NMOM=6) | N-body | 256 | shared `(6·NB)`, static |
+| 2D joint (NMOM=1) | N-body | 1024 | shared `(n_dist·n_val)` |
+| 2D single-pass (NMOM=6) | N-body | 1024 | **dynamic** shared `(6·n_dist·n_val)` sums+counts |
+
+- **TILE=1024 for 2D** (measured, job 238806): on 50×50 the dynamic hist (117KB)
+  pins 1 block/SM, so threads/block IS occupancy. 1024→50% occ = **8.36 bapps**
+  (192.8s) vs 512→25%=6.39 (252.6s) vs 256→12.5%=3.68. The larger tile's extra
+  serial j-work is more than repaid. Static staging at 1024 = 32KB (4 arrays×2×1024×4B);
+  32KB+117KB = 149KB < A100 163KB. For small hist all TILEs hit ~100% occ (256≈512≈1024),
+  so a single TILE=1024 is safe across 2D. **On smaller GPUs** (L40 100KB) the 1024
+  staging+hist may not fit → device-aware fallback drops TILE then static/global.
+- **Counts on-chip** (sums+counts both in shared). counts→global measured 3–20× SLOWER.
+- **No replication (R=1)**, **no value-axis tiling**, **no warp-aggregation** — all
+  measured net-negative for our scattered-bin regime.
+- **Dynamic shared** (CC7.0+ opt-in via `CuDynamicSharedArray` + max-dynamic-smem
+  attribute). Device-aware: query `MAX_SHARED_MEMORY_PER_BLOCK_OPTIN` (A100 163KB,
+  L40 100KB, V100 96KB). If `6·n_dist·n_val·8 + staging` exceeds it (huge bins on a
+  small GPU), fall back to the static-shared/global path.
+- fixed-x: identical structure; `x` from `(D,N)` (broadcast across batch), `u` per-b.
+- 3D: identical, D=3.
+
+## Implementation note (backend specialization)
+KA `@localmem` is static-only (≤48KB) and KA exposes no warp/dynamic-shared ops, so
+the fast path is **CUDA-specialized** (a CUDA kernel via `@cuda` + `CuDynamicSharedArray`),
+dispatched on the CUDA backend type. The portable KA kernels remain as the CPU
+reference. `GPUBackend{B}` is parametric precisely to allow this.
+
+## Final expected times @ N=20000, B=8064 (extrapolated, single-pass unless noted)
+| path | bins | time |
+|------|------|------|
+| 1D individual | NB=50 | ~10–11 s (152 bapps) |
+| 1D single-pass | NB=50 | ~50–60 s |
+| 2D joint (1 SF) | 50×50 | ~31 s |
+| 2D single-pass | 16×8 | ~120 s |
+| 2D single-pass | 20×20 | ~135 s |
+| 2D single-pass | 50×50 | **~58 s** (TILE=1024, linear value bins) — ~17× the old 974 s |
+
+**Integrated-path timing (job 238895, public API, N=20000):** 50×50 SP2D fixed-x =
+0.457 s @ B=64 = **28 bapps → ~58 s @ B=8064**. This beats the proto's 192.8 s
+estimate because the proto used a *general* (binary-search) value plan; the real
+workload's `LinearBinEdges` value bins hit the **O(1) FMA digitize**
+(`GPUValueLinearShared`), ~3× faster in the 6-per-pair value-digitize hot loop.
+Lesson: benchmark with the production value-plan type, not a general fallback.
+
+2D-SP is intrinsically heavy (6 invariants × 2D × 1.6e12 pairs); 50×50 ≈ 252 s is
+near its practical floor on this hardware with the on-chip-histogram approach.
+
+---
+
+# IMPLEMENTED + VALIDATED (final state, jobs 238837/238895/239150/239164/239175)
+
+`StructureFunctionsCUDAExt = ["KernelAbstractions","CUDA"]` holds the CUDA fast
+kernels (`ext/cuda/kernels_{1d,2d}.jl`); it overrides package stubs
+`gpu_fast_launch_{1d,2d}_batch!` (default `false` → KA fallback) on
+`::CUDA.CUDABackend`. GPUExt's `_sf_launch_{1d,2d}_batch!` call the hook first.
+Shared device-callable building blocks (`_sf_moments`, `_sf_dot`,
+`_gpu_digitize_value_plan`, digitizers, value plans) reused from GPUExt via
+`const GE = Base.get_extension(...)`. Batch + slices dispatch all funnel through
+the unified launchers; non-batch (B=1, sub-10 ms) stays on the existing tiled128
+path. Full CPU suite 4374/4374 green.
+
+## Final per-regime routing (measured-optimal, histograms verified equal)
+| regime | kernel | bapps | @ B/T=8064 |
+|--------|--------|-------|-----------|
+| 1D individual **fixed-x** | OLD global warp-replica + W-strip | 147 | 11 s |
+| 1D individual varying-x | **N-body** broadcast | 115 | 14 s (1.9× old 61) |
+| SP1D (fixed + varying) | **N-body** | 43 | 37 s (1.4× old 30; beats 6×separate=84 s) |
+| joint 2D (fixed + varying) | **N-body** + shared hist | — | — |
+| **SP2D 50×50** (fixed + varying) | **N-body** + dyn-shared, TILE=1024 | 28 | **58 s (~17× old 974 s)** |
+
+Decisive finding: **the optimum is regime-dependent**. 1D-individual-fixed-x has a
+tiny histogram and is contention-bound → the old global-warp-replica design (R=8
+global replicas, geometry amortized over a W-strip) beats every shared-histogram
+N-body variant (incl. an N-body + W-strip kernel, which measured *slower* at 108
+bapps — geometry amortization doesn't pay when occupancy/contention dominate). All
+other regimes are geometry- or atomic-bound → N-body broadcast (+ dynamic-shared
+for large 2D) wins, by up to 17×. "One kernel for everything" is NOT optimal; the
+dispatch routes each regime to its measured winner.
+
+Parity: exact integer counts across all regimes on GPU vs CPU; sums within FP32
+reduction-order tolerance (≤ ~1e-3 relative on near-cancelling single-pass cells;
+≤ ~1e-5 elsewhere). GPU↔CPU count parity is exact except at value-bin edges where
+FMA rounding can move a handful of pairs — use `atol`, not exact equality, for
+GPU-vs-CPU sum comparisons.
+
+---
+
+# Lessons & RULED-OUT approaches (measured — do NOT re-try)
+
+Every item below cost at least one A100 run. They are settled; re-deriving them
+wastes GPU time. Raw evidence is in `gpu/benchmark_results/` (job IDs cited).
+
+## Algorithmic levers that were tested and LOST
+| approach | result | why it loses |
+|----------|--------|--------------|
+| Shared-histogram **replication** R>1 (1D) | R1=33, R2=34, R4=23, R8=12, R16=PTX overflow (NMOM6,N8000,B16) | extra shared replicas cut occupancy; A100 shared atomics are fast enough that contention-spreading isn't worth it |
+| Fixed-x **W-strip** on the *shared-hist* 1D kernel (NMOM=6) | W1=34, W2=31, W4=22, W8=12 | same — striping blows occupancy for the 6× histogram |
+| **counts → global** (sums on-chip, counts global), 2D-SP | 0.6–2.0 vs 12.6 bapps both-on-chip (job 238789) | global count-atomics dominate; occupancy gain from halving shared not worth it. **Keep sums+counts BOTH on-chip.** |
+| **Value-axis tiling** (split value bins into slabs for occupancy), 2D-SP | slower everywhere (jobs 238805/238806) | nslabs× pair re-traversal > occupancy gain |
+| **N-body + W-strip geometry amortization**, 1D-individual-fixed | 108 vs 115 bapps plain N-body (job 239154) | geometry amortization doesn't pay when the regime is contention/occupancy-bound, not geometry-bound |
+| **Warp-aggregated atomics** (`match.any.sync`) | not pursued — research-confirmed marginal | only pays when warp lanes share few bins; our bins are scattered → degenerates to ~32 atomics. `match_any_sync` also absent from the CUDACore stack (reachable only via raw llvmcall). `redux.sync.add` is integer-only. |
+| Unified "one kernel for all regimes" | 1D-individual-fixed regressed ~28% | **the optimum is regime-dependent** — see routing table above. Dispatch per regime. |
+| Old varying-x 2D (`sf_tiled_2d_varying!` direct global atomics) | 7× slower than shared-hist (job 238782) | 2D needs a privatized (shared/dynamic-shared) histogram, not direct global atomics |
+
+## Things that WON (and the decisive evidence)
+- **N-body broadcast** (thread owns point i, loops j over staged tile → all lanes read same `shared[j]`): 1.36–2.0× over thread-owns-a-pair for geometry-bound 1D (job 238798). The ~7× gap to CADISHI was *structure* (scattered reads + per-pair sqrt-decode), not atomics.
+- **Dynamic shared memory** (`CuDynamicSharedArray` + `FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`): unlocks the full single-pass 2D histogram on-chip (A100 163 KB opt-in vs 48 KB static). This is what makes 50×50 SP2D fit.
+- **TILE=1024 for 2D**: 50% occupancy beats 25% (TILE=512) on the histogram-pinned 50×50 case — 8.36 vs 6.39 bapps (job 238806).
+- **O(1) FMA value digitize** (`GPUValueLinearShared` from `LinearBinEdges`) vs general binary-search (`GPUValueVectorCols`): ~3× in the 6-per-pair hot loop → 58 s vs the proto's 193 s estimate. **Always benchmark with the production value-plan type, not a general fallback.**
+- **Single fused launch** for batch/slices (no host `for b`/`for slice` loop): the original ~17 s batch-joint2d regression was a naive per-cell `(N,N)` kernel inside a host loop.
+- **Stagger the REPLICA index, never the bin index** (if replication is ever used): offsetting the bin corrupts the histogram — the prior botched attempt.
+
+## Compile pitfalls (KA.CPU() catches NONE — only `@cuda` compile does)
+- `threadIdx().x`/`blockIdx().x`/`blockDim().x` return **Int32** → convert to `Int` at kernel top, or device helpers annotated `::Int` throw `jl_f_throw_methoderror`. (A ternary `lid+1 : 1` promotes to Int64, so the *second* use can compile while the first raw-Int32 use throws.)
+- `zero(eltype(localmem))` / `zero(::DataType)` doesn't constant-fold → methoderror. Use `zero(FT)` with `FT` a concrete type param.
+- Looped reads/writes/atomics on a shared array passed as a **function argument** fail to compile on the CUDACore stack — write them **inline** in the kernel body (single-element `@inline` loads are fine).
+- **Dynamic-shared opt-in must be set when STATIC+DYNAMIC shared > 48 KB**, not only when the dynamic part alone exceeds it (job 238836 bug: NMOM=1 50×50 had 20 KB dynamic + 32 KB static staging = 52 KB > 48 KB default cap → launch failed until the attribute was set unconditionally).
+- Non-bitstype kernel args (e.g. an untyped `edges_dev::Any` field) → KernelError; type the field + add an `Adapt.adapt_structure` rule.
+- Workflow that catches everything but InvalidIRError for free, on the login node (no GPU): `Meta.parseall` + `using StructureFunctions, KernelAbstractions, CUDA` (extension load/precompile). Only `@cuda` compile (sbatch) catches InvalidIRError.
+
+## Reproducing the validation (each is a self-contained `gpu/` script + `run_*.sh`)
+- `gpu/test_cuda_2d_parity.jl` — 2D kernel parity (CUDA vs KA.CPU), 12 combos.
+- `gpu/test_cuda_1d_parity.jl` — 1D kernel parity + timing + joint2d-varying FP-boundary check.
+- `gpu/bench_1d_old_vs_nbody.jl` — the head-to-head that decided 1D per-regime routing.
+- `gpu/test_e2e_2d_cuda.jl`, `gpu/test_slices_e2e.jl` — public-API parity vs serial + timing.

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -29,6 +29,7 @@ General user documentation lives in [`docs/gpu.md`](../docs/gpu.md).
 | `benchmark_workspace.jl` | Workspace reuse timing. |
 | `benchmark_slices.jl` | Slice-batch driver timing. |
 | `benchmark_batch_matrix.jl` | Current auxiliary-axis batch matrix benchmark. |
+| `benchmark_batch_breakdown.jl` | Phase timing for batch fixed-x (kernel vs merge vs adapt vs download). |
 | `benchmark_scaling_helpers.jl` | Shared timing helpers for maintained benchmark and asset scripts. |
 | `collect_benchmark_assets.jl` | Generates `gpu/benchmark_results/assets_latest.json` for docs/README figures. |
 | `collect_multi_gpu_scaling.jl` | Future multi-GPU scaling collector; retained as a maintained placeholder. |
@@ -114,6 +115,92 @@ and prints these ratios:
 
 Use `BENCH_BACKEND=kacpu` only as a smoke test that the benchmark still runs. Treat
 performance ratios as meaningful only under CUDA allocation and representative `N/BATCH`.
+
+For the large auxiliary-axis matrix runs, load `benchmark_batch_matrix.jl` once and
+call `run_batch_matrix_benchmark` directly:
+
+```julia
+include_gpu("benchmark_batch_matrix.jl")
+
+# N=20_000, B=8064, 16 distance bins, 8 value bins.
+run_batch_matrix_benchmark(profile = :reference, allow_slow = true)
+
+# Same long auxiliary run with 20 x 20 distance/value bins.
+run_batch_matrix_benchmark(profile = :reference, allow_slow = true, n_dist = 20, n_val = 20)
+
+# Same long auxiliary run with 50 x 50 distance/value bins.
+run_batch_matrix_benchmark(profile = :reference, allow_slow = true, n_dist = 50, n_val = 50)
+```
+
+The default reference cases run the fixed-position batch routes, the individual
+varying-position GPU-slice route, and an eight-slice explicit GPU baseline sample.
+They also run sampled varying-position SP1D/SP2D routes and extrapolate to full `B`.
+The full varying-position SP1D/SP2D routes are intentionally opt-in because they can
+take many minutes at `N=20_000`, `B=8064`. Add those cases explicitly only when you
+mean to measure the full route:
+
+```julia
+run_batch_matrix_benchmark(
+    profile = :reference,
+    allow_slow = true,
+    cases = (:sp1d_varying_gpu_sample, :sp2d_varying_gpu_sample),
+)
+
+run_batch_matrix_benchmark(
+    profile = :reference,
+    allow_slow = true,
+    cases = (:sp1d_varying, :sp2d_varying),  # full B, expected to be slow
+)
+```
+
+For an exact all-slice explicit GPU baseline, include `:individual_fixed_gpu_full`.
+The shell `PROFILE=... ALLOW_SLOW=1` wrapper still exists for batch scripts, but the
+REPL function is the maintained interface.
+
+To diagnose varying-position performance, compare the public varying route against
+an explicit loop over the optimized point-field GPU route:
+
+```julia
+run_batch_matrix_benchmark(
+    profile = :reference,
+    allow_slow = true,
+    B = 80,
+    explicit_samples = 8,
+    cases = (
+        :individual_varying,
+        :individual_varying_explicit_gpu_sample,
+        :sp1d_varying_gpu_sample,
+        :sp1d_varying_explicit_gpu_sample,
+        :sp2d_varying_gpu_sample,
+        :sp2d_varying_explicit_gpu_sample,
+    ),
+)
+```
+
+If the explicit optimized loop is faster, the fused varying-position route should be
+replaced or redesigned. If both are slow, investigate the point-field route,
+workspace reuse, and device-view staging first.
+
+## A100 performance gates (`profile = :reference`)
+
+Run on a GPU node after batch-kernel changes:
+
+```bash
+julia --project=gpu -e 'include("gpu/benchmark_batch_matrix.jl");
+    run_batch_matrix_benchmark(profile=:reference, allow_slow=true)'
+nsys profile -o batch_fixed_x --trace=cuda,nvtx --force-overwrite=true \
+    julia --project=gpu gpu/profile_batch_fixed_x.jl
+nsys stats --force-export=true --report cuda_gpu_kern_sum batch_fixed_x.nsys-rep
+```
+
+Dev timing split: `gpu/benchmark_batch_breakdown.jl`. Working notes: `gpu/benchmark_results/`.
+
+| Gate | Target |
+|------|--------|
+| `N=20_000`, `B=8064`, `individual_fixed` | beat explicit slice extrapolation; stretch < 10 s hot launch |
+| `workspace_speedup`, `sp2d_vs_6x_joint2d` | > 1.0× (open) |
+
+Record logs under `gpu/benchmark_results/`.
 
 ## Current Output Contracts
 

--- a/gpu/SP2D_HTP_EJ.md
+++ b/gpu/SP2D_HTP_EJ.md
@@ -1,10 +1,10 @@
-# Eight-type single-pass 2D (SP2D) — HTP-EJ GPU path
+# Six-invariant single-pass 2D (SP2D) — HTP-EJ GPU path
 
-**Code:** `ext/TiledSinglePass2DPrivKernels.jl`, `ext/SP2DPrivPolicy.jl`, `ext/SP2DPrivLaunch.jl`  
-**Benchmark:** `gpu/benchmark_2d_grid_scaling.jl` (run on GPU allocation)  
-**Tests:** `test/test_gpu_sp2d_priv.jl` (KA.CPU parity for `:shared`, `:typeplane`, `:direct`)
+**Code:** `ext/gpu/kernels_2d_direct.jl`, `ext/gpu/sp2d_accumulation_strategy.jl`, `ext/gpu/value_digitize_plans.jl`, `ext/gpu/launch.jl`, `ext/gpu/workspace.jl`
+**Benchmark:** `gpu/benchmark_2d_grid_scaling.jl` (run on GPU allocation)
+**Tests:** `test/test_gpu_sp2d_partitioned.jl` (KA.CPU parity for `:shared`, `:typeplane`, `:direct`)
 
-This document describes how production **eight-type single-pass 2D** histograms work on GPU,
+This document describes how production **six-invariant single-pass 2D** histograms work on GPU,
 why the design looks the way it does, and what is *not* solved yet.
 
 ---
@@ -14,10 +14,12 @@ why the design looks the way it does, and what is *not* solved yet.
 For each unordered pair `(i, j)` with `i < j` (same tiled128 schedule as 1D / joint 2D):
 
 1. Distance `dist` → **one** distance-bin index.
-2. Eight structure-function samples (longitudinal / transverse quadratic and mixed types).
+2. Six invariant structure-function samples:
+   `S2 = |δu|²`, `L2 = δu_L²`, `T2 = |δu_T|²`,
+   `S3 = δu_L |δu|²`, `L3 = δu_L³`, and `LT2 = δu_L |δu_T|²`.
 3. Each sample → **value-bin** index → accumulate into `sums[t, dist_bin, val_bin]` and counts.
 
-Output shape: `(8, n_dist, n_val)`. One kernel launch covers all eight types (vs eight separate `joint_2d` passes).
+Output shape: `(6, n_dist, n_val)`. One kernel launch covers all six invariants (vs six separate `joint_2d` passes).
 
 Production value routing uses typed digitize plans (`GPUValueDigitizePlan`: linear, log, Inf-padded, per-column, etc.).
 
@@ -25,40 +27,40 @@ Production value routing uses typed digitize plans (`GPUValueDigitizePlan`: line
 
 ## Two algorithms (three `accum_mode` labels)
 
-Policy is frozen per workspace in [`SP2DPrivConfig`](../ext/SP2DPrivPolicy.jl) from the **48 KiB default** shared-memory budget (`SF_GPU_SMEM_DEFAULT`). No per-grid tuning.
+The accumulation strategy is frozen per workspace in `SP2DAccumulationStrategy` from the **48 KiB default** shared-memory budget (`SF_GPU_SMEM_DEFAULT`). No per-grid tuning.
 
 | `accum_mode` | When | Pair traversal | Block-end output |
 |--------------|------|----------------|------------------|
-| `:shared` | Full `C = 8·n_dist·n_val` fits in smem | **1×** tile loop | On-chip flush → `out_*` (`@atomic`, joint pattern) |
-| `:typeplane` | One `n_dist×n_val` plane fits, not all 8 types | **`n_type_passes`** tile loops (`types_per_pass` types per pass) | Same on-chip flush each pass |
-| `:direct` | Even one plane does not fit | **1×** tile loop, global atomics to block-private slab | Priv slab + merge kernel → `out_*` |
+| `:shared` | Full `C = 6·n_dist·n_val` fits in smem | **1×** tile loop | On-chip flush → `out_*` (`@atomic`, joint pattern) |
+| `:typeplane` | One `n_dist×n_val` plane fits, not all 6 types | **`n_type_passes`** tile loops (`types_per_pass` types per pass) | Same on-chip flush each pass |
+| `:direct` | Even one plane does not fit | **1×** tile loop, global atomics to block-private slab | private partition + merge kernel → `out_*` |
 
 `:shared` and `:typeplane` are the **same on-chip family** (shared histogram during the pair loop, flush like `joint_2d`). They differ only in how many type planes fit per pass.
 
 `:direct` is the fallback when smem cannot hold even `n_dist × n_val` cells (large bin grids).
 
-`needs_priv_merge == (accum_mode == :direct)` — host routing uses this single boolean (`_launch_sp2d_onchip!` vs `_launch_sp2d_direct_priv!`).
+`needs_partition_merge == (accum_mode == :direct)` — host routing uses this single boolean (`_launch_sp2d_onchip!` vs `_launch_sp2d_direct_partitioned!`).
 
 ```mermaid
 flowchart TD
-  cfg["_sp2d_priv_config(n_dist, n_val)"]
+  cfg["_sp2d_accumulation_strategy(n_dist, n_val)"]
   cfg -->|C le max_shared| shared[":shared"]
   cfg -->|plane le max_shared| typeplane[":typeplane"]
   cfg -->|plane gt max_shared| direct[":direct"]
   shared --> onchip["On-chip: shared hist + atomic flush to out_*"]
   typeplane --> onchip
-  direct --> priv["Priv slab + merge kernel"]
+  direct --> partitions["private partition + merge kernel"]
 ```
 
 ### On-chip flush (current production path for typical grids)
 
-Before 2025 on-chip fix, **all** modes incorrectly routed through a block-private slab and serial merge (~7 ms + ~2 GB memset at `N=20k`), even when shared memory already held the histogram. That made e2e ≈ `8×joint_2d` with no margin.
+Before the on-chip fix, **all** modes incorrectly routed through a block-private slab and serial merge (~7 ms + ~2 GB memset at `N=20k`), even when shared memory already held the histogram. That made e2e ≈ `6×joint_2d` with no margin.
 
-**Now:** `:shared` / `:typeplane` write directly to `out_sums_dev` / `out_cnts_dev` at block end (mirror `TiledStructureFunctionKernels.jl` joint flush). No priv allocation, no merge.
+**Now:** `:shared` / `:typeplane` write directly to `out_sums_dev` / `out_cnts_dev` at block end (mirror `TiledStructureFunctionKernels.jl` joint flush). No private allocation, no merge.
 
 ### Direct path
 
-When planes do not fit in 48 KiB, pairs accumulate with **global atomics** into `(8, n_dist, n_val, n_tile_blocks)` priv slabs, then `_launch_merge_sp2d_priv!` (serial by default; `ENV["SP2D_MERGE"]=parallel` for experiments only).
+When planes do not fit in 48 KiB, pairs accumulate with **global atomics** into `(6, n_dist, n_val, n_tile_blocks)` private partitions, then `_launch_merge_sp2d_partitions!` (serial by default; `ENV["SP2D_MERGE"]=parallel` for experiments only).
 
 ---
 
@@ -66,24 +68,24 @@ When planes do not fit in 48 KiB, pairs accumulate with **global atomics** into 
 
 | Piece | Role |
 |-------|------|
-| `GPUSFWorkspace(...; kind=:single_pass_2d)` | Device `out_*`, frozen `sp2d_priv_config`, cached `sp2d_pair_kernel` (typed dist + val plan) |
+| `GPUSFWorkspace(...; kind=:single_pass_2d)` | Device `out_*`, frozen `sp2d_accumulation_strategy`, cached `sp2d_pair_kernel` (typed dist + val plan) |
 | `_sp2d_resolve_pair_kernel` | One-time kernel bind per workspace; ephemeral calls resolve once per launch |
-| `reset_histogram!` | Zeros `out_*` always; zeros `priv_*` only when `needs_priv_merge` |
-| `_ensure_sp2d_priv_bufs!` | Allocates priv slabs only for `:direct` |
+| `reset_histogram!` | Zeros `out_*` always; zeros private partitions only when `needs_partition_merge` |
+| `_ensure_sp2d_partition_bufs!` | Allocates private partitions only for `:direct` |
 
-Distance bins must be `LinearBinEdges` or `LogBinEdges` for the HTP-EJ tiled path (`Vector` dist edges use non-priv tiled / legacy routes).
+Distance bins must be `LinearBinEdges` or `LogBinEdges` for the HTP-EJ tiled path. Other distance-bin forms route to explicitly supported fallback kernels or throw.
 
 ---
 
 ## Benchmark gate (`benchmark_2d_grid_scaling.jl`)
 
-Compares **end-to-end** `gpu_calculate_structure_functions_single_pass_2d!` against **`8 × joint_2d`** (eight separate single-type 2D runs). This is the production-relevant gate (eight histogram tensors in one API call).
+Compares **end-to-end** `gpu_calculate_structure_functions_single_pass_2d!` against **`6 × joint_2d`** (six separate single-type 2D runs). This is the production-relevant gate (six histogram tensors in one API call).
 
-**Asymmetry (intentional):** joint reference uses one `L2SFType` + `InfPaddedBinEdges` value edges (same family as SP2D); SP2D uses eight types + typed value digitize plans. Joint value axis still uses general edge search until a typed joint kernel exists. The gate is conservative.
+**Asymmetry (intentional):** joint reference uses one `L2SFType` + `InfPaddedBinEdges` value edges (same family as SP2D); SP2D uses six invariant samples + typed value digitize plans. Joint value axis still uses general edge search until a typed joint kernel exists. The gate is conservative.
 
 Example A100 (`N=20000`) after on-chip flush:
 
-| Grid | Mode | 8×joint | SP2D e2e | Merge |
+| Grid | Mode | 6×joint | SP2D e2e | Merge |
 |------|------|---------|----------|-------|
 | 20×22 | `:shared` | 53 ms | **28 ms** | 0 |
 | 50×52 | `:typeplane` 2×4 | 64 ms | **43 ms** | 0 |
@@ -98,28 +100,28 @@ A common intuition: 2D joint needs **two** digitizations per pair (distance + va
 
 **That bound is too optimistic.** Per pair, SP2D actually does:
 
-| Work | `joint_2d` | `sp1d` (8 types) | `sp2d` (8 types) |
+| Work | `joint_2d` | `sp1d` (6 invariants) | `sp2d` (6 invariants) |
 |------|------------|------------------|------------------|
 | Distance digitize | 1 | 1 | 1 |
-| Value digitize | 1 | 0 | **8** (one per SF type) |
-| SF values computed | 1 | 8 | 8 |
-| Histogram cells touched | 1 | 8 (1D bins) | 8 (2D bins) |
+| Value digitize | 1 | 0 | **6** (one per invariant) |
+| SF values computed | 1 | 6 | 6 |
+| Histogram cells touched | 1 | 6 (1D bins) | 6 (2D bins) |
 | Tile traversals | 1 | 1 | **`n_type_passes`** (e.g. 4 on 50×52) |
 
 Additional costs not present in single-type joint:
 
-- **Eight value digitizations** (Inf-padded / per-column routes are heavier than one shared linear digitize).
-- **Typeplane multi-pass:** when `C = 8·n_dist·n_val` exceeds smem, the tile schedule is replayed `n_type_passes` times with `@synchronize` between zero / pair / flush phases — not amortized to a single pass.
+- **Six value digitizations** (Inf-padded / per-column routes are heavier than one shared linear digitize).
+- **Typeplane multi-pass:** when `C = 6·n_dist·n_val` exceeds smem, the tile schedule is replayed `n_type_passes` times with `@synchronize` between zero / pair / flush phases — not amortized to a single pass.
 - **Larger on-chip histogram:** static `@localmem` width is `max_shared_cells` (compile-time), not `C`; zero/flush loops scale with active cells.
 - **Block-end flush:** on-chip modes use global `@atomic` adds into `(8, n_dist, n_val)` — correct and cheap vs merge, but not free at large `C` and many tile blocks.
 - **Host e2e:** staging, `reset_histogram!`, optional `Array(out_sums_dev)` download (~3 ms in recent profiles).
 
 So the fair structural comparisons are:
 
-- vs **`8 × joint_2d`** — current production gate (passed with margin on tested grids).
-- vs **`sp1d`** — SP2D adds an entire value axis + 8 value digitizes; ratios of 2–6× are expected, not a bug by themselves.
+- vs **`6 × joint_2d`** — current production gate (passed with margin on tested grids).
+- vs **`sp1d`** — SP2D adds an entire value axis + six value digitizations; ratios of 2–6× are expected, not a bug by themselves.
 
-A tighter *theoretical* target for “2D overhead only” would be **one** `joint_2d` plus ~8× value-digitize work in a fused kernel — not implemented; today we pay full eight-type structure in one tiled kernel.
+A tighter *theoretical* target for “2D overhead only” would be **one** `joint_2d` plus ~6× value-digitize work in a fused kernel — not implemented; today we pay full six-invariant structure in one tiled kernel.
 
 ---
 
@@ -133,7 +135,7 @@ Ordered roughly by expected impact vs implementation risk:
 4. **Host hot path** — reuse download buffers in workspace; avoid per-call `Array(out_sums_dev)` if profiling shows it matters.
 5. **Optional smem budget** — portable override above 48 KiB (e.g. 96 KiB) with explicit occupancy measurement; not assumed win.
 6. **Direct-mode merge** — parallel merge remains comparison-only; serial merge is production default.
-7. **Policy cleanup** — optional rename `:shared`/`:typeplane` → single `:onchip` label with `n_type_passes` (cosmetic).
+7. **Strategy naming cleanup** — optional rename `:shared`/`:typeplane` → single `:onchip` label with `n_type_passes` (cosmetic).
 
 Re-profile after each change with `benchmark_2d_grid_scaling.jl` across several `(n_dist, n_val)` points, not a single production grid.
 
@@ -143,4 +145,3 @@ Re-profile after each change with `benchmark_2d_grid_scaling.jl` across several 
 
 - [GPU_2d_joint_sf_plan.md](GPU_2d_joint_sf_plan.md) — single-type joint 2D tiled path
 - [docs/gpu.md](../docs/gpu.md) — workspace, slice batches, testing tiers
-- [GPU_structure_function_prototypes_theory.md](GPU_structure_function_prototypes_theory.md) — historical prototype research (1D focus)

--- a/gpu/bench_1d_old_vs_nbody.jl
+++ b/gpu/bench_1d_old_vs_nbody.jl
@@ -1,0 +1,72 @@
+# =============================================================================
+# Head-to-head: OLD batch launchers (global warp-replica + W-strip + merge) vs
+# NEW CUDA N-body kernels, for the 1D regimes, at the SAME config (N=20000).
+# Decides per-regime routing for "optimal everywhere". Also verifies the two
+# produce equal histograms.
+#   julia --project=gpu gpu/bench_1d_old_vs_nbody.jl
+# =============================================================================
+using StructureFunctions
+import KernelAbstractions as KA
+using CUDA, Printf
+using Statistics: median
+const SF = StructureFunctions
+const SFC = SF.Calculations
+const GE = Base.get_extension(SF, :StructureFunctionsGPUExt)
+const SFT = SF.StructureFunctionTypes
+using StructureFunctions: LinearBinEdges
+const FT = Float32
+const sf2 = SFT.L2SFType()
+const N = parse(Int, get(ENV, "SF_N", "20000"))
+const B = parse(Int, get(ENV, "SF_B", "64"))
+const NB = 50
+const D = 2
+const BE = CUDA.CUDABackend()
+tput(t) = (N*(N-1)/2)*B/t/1e9
+bench(f) = (f(); f(); ts = Float64[]; for _ in 1:5; t = time_ns(); f(); push!(ts, (time_ns()-t)/1e9); end; median(ts))
+
+lbe = LinearBinEdges(collect(range(0.05f0, 2.0f0; length = NB + 1)))
+dig = GE._sf_batch_dist_digitizer(BE, lbe)
+x_fix = rand(FT, D, N); u = randn(FT, D, N, B); x_var = rand(FT, D, N, B)
+
+println("OLD vs N-body, 1D, N=$N B=$B NB=$NB\n")
+println("| regime | old bapps (s@8064) | nbody bapps (s@8064) | winner | equal? |")
+
+# ---- individual fixed (NMOM=1) ----
+let
+    xo, uo = GE._stage_batch_device(BE, x_fix, u; fixed_x = true)
+    so = CUDA.zeros(FT, NB, B); co = CUDA.zeros(UInt32, NB, B)
+    fo() = (CUDA.fill!(so,0f0); CUDA.fill!(co,UInt32(0)); GE._launch_batch_fixed_x_sf!(BE, so, co, xo, uo, sf2, N, B, lbe); CUDA.synchronize())
+    to = bench(fo)
+    xn = CuArray(x_fix); un = CuArray(u); sn = CUDA.zeros(FT,1,NB,B); cn = CUDA.zeros(UInt32,1,NB,B)
+    fn() = (CUDA.fill!(sn,0f0); CUDA.fill!(cn,UInt32(0)); SFC.gpu_fast_launch_1d_batch!(BE, sn, cn, xn, un, sf2, dig, N, NB, B, D, 1, true); CUDA.synchronize())
+    tn = bench(fn)
+    eq = Array(co) == reshape(Array(cn), NB, B)
+    @printf("| ind fixed | %.0f (%.1f) | %.0f (%.1f) | %s | %s |\n", tput(to), to*8064/B, tput(tn), tn*8064/B, tput(to)>tput(tn) ? "OLD" : "nbody", eq)
+end
+
+# ---- individual varying (NMOM=1) ----
+let
+    xo, uo = GE._stage_batch_device(BE, x_var, u; fixed_x = false)
+    so = CUDA.zeros(FT, NB, B); co = CUDA.zeros(UInt32, NB, B)
+    fo() = (CUDA.fill!(so,0f0); CUDA.fill!(co,UInt32(0)); GE._launch_batch_varying_x_sf!(BE, so, co, xo, uo, sf2, N, B, lbe); CUDA.synchronize())
+    to = bench(fo)
+    xn = CuArray(x_var); un = CuArray(u); sn = CUDA.zeros(FT,1,NB,B); cn = CUDA.zeros(UInt32,1,NB,B)
+    fn() = (CUDA.fill!(sn,0f0); CUDA.fill!(cn,UInt32(0)); SFC.gpu_fast_launch_1d_batch!(BE, sn, cn, xn, un, sf2, dig, N, NB, B, D, 1, false); CUDA.synchronize())
+    tn = bench(fn)
+    eq = Array(co) == reshape(Array(cn), NB, B)
+    @printf("| ind varying | %.0f (%.1f) | %.0f (%.1f) | %s | %s |\n", tput(to), to*8064/B, tput(tn), tn*8064/B, tput(to)>tput(tn) ? "OLD" : "nbody", eq)
+end
+
+# ---- SP1D fixed (NMOM=6) ----
+let
+    xo, uo = GE._stage_batch_device(BE, x_fix, u; fixed_x = true)
+    so = CUDA.zeros(FT, 6, NB, B); co = CUDA.zeros(UInt32, 6, NB, B)
+    fo() = (CUDA.fill!(so,0f0); CUDA.fill!(co,UInt32(0)); GE._launch_batch_fixed_x_sp1d!(BE, so, co, xo, uo, N, B, lbe); CUDA.synchronize())
+    to = bench(fo)
+    xn = CuArray(x_fix); un = CuArray(u); sn = CUDA.zeros(FT,6,NB,B); cn = CUDA.zeros(UInt32,6,NB,B)
+    fn() = (CUDA.fill!(sn,0f0); CUDA.fill!(cn,UInt32(0)); SFC.gpu_fast_launch_1d_batch!(BE, sn, cn, xn, un, sf2, dig, N, NB, B, D, 6, true); CUDA.synchronize())
+    tn = bench(fn)
+    eq = Array(co) == Array(cn)
+    @printf("| SP1D fixed | %.0f (%.1f) | %.0f (%.1f) | %s | %s |\n", tput(to), to*8064/B, tput(tn), tn*8064/B, tput(to)>tput(tn) ? "OLD" : "nbody", eq)
+end
+println("\nDONE_BENCH")

--- a/gpu/benchmark_batch_matrix.jl
+++ b/gpu/benchmark_batch_matrix.jl
@@ -1,13 +1,19 @@
-# Production batch matrix benchmark (rows 1–7).
+# Production auxiliary-axis batch matrix benchmark.
 #
-# Default is FAST (~1–2 min on GPU). Do not run full N=20k B=8064 in a dev loop.
+# Preferred REPL use inside a SLURM GPU allocation:
 #
-#   julia --project=gpu gpu/benchmark_batch_matrix.jl                    # N=512 B=16
-#   PROFILE=scaled julia --project=gpu gpu/benchmark_batch_matrix.jl     # N=4096 B=512
+#   include("gpu/benchmark_batch_matrix.jl")
+#   run_batch_matrix_benchmark(profile = :quick)
+#   run_batch_matrix_benchmark(profile = :reference, allow_slow = true,
+#       cases = (:individual_fixed, :individual_fixed_gpu_sample, :individual_varying))
+#
+# CLI compatibility remains available:
+#
+#   julia --project=gpu gpu/benchmark_batch_matrix.jl
 #   PROFILE=reference ALLOW_SLOW=1 julia --project=gpu gpu/benchmark_batch_matrix.jl
-#       # N=20k B=8064 batch rows only; slice baseline = 8-sample extrapolation
 #
-# Full exact B×slice baseline: PROFILE=reference_full ALLOW_SLOW=1 (hours — acceptance only)
+# The explicit slice baselines in this file are GPU baselines. CPU serial baselines
+# belong in CPU benchmark scripts and are intentionally not mixed into this matrix.
 using Printf: @printf
 using CUDA: CUDA
 using KernelAbstractions: KernelAbstractions as KA
@@ -18,38 +24,59 @@ using StructureFunctions:
 
 include(joinpath(@__DIR__, "benchmark_scaling_helpers.jl"))
 
-const _PROFILE_SIZES = Dict(
+const PROFILE_SIZES = Dict(
     :quick => (N = 512, B = 16),
     :scaled => (N = 4096, B = 512),
     :reference => (N = 20_000, B = 8064),
-    :reference_full => (N = 20_000, B = 8064),
 )
 
-function _resolve_profile()
-    raw = lowercase(strip(get(ENV, "PROFILE", get(ENV, "FAST", "1") == "1" ? "quick" : "scaled")))
-    sym = Symbol(raw)
-    sym in keys(_PROFILE_SIZES) || error(
-        "PROFILE must be quick, scaled, reference, or reference_full; got $(repr(raw))",
-    )
-    return sym
+const DEFAULT_CASES = (
+    :individual_fixed,
+    :individual_fixed_gpu_sample,
+    :individual_varying,
+    :sp1d_fixed,
+    :sp1d_varying_gpu_sample,
+    :sp2d_fixed,
+    :sp2d_varying_gpu_sample,
+    :joint2d_fixed,
+)
+
+const ALL_CASES = (
+    :individual_fixed,
+    :individual_fixed_gpu_sample,
+    :individual_fixed_gpu_full,
+    :individual_varying,
+    :individual_varying_explicit_gpu_sample,
+    :sp1d_fixed,
+    :sp1d_varying_gpu_sample,
+    :sp1d_varying_explicit_gpu_sample,
+    :sp1d_varying,
+    :sp2d_fixed,
+    :sp2d_varying_gpu_sample,
+    :sp2d_varying_explicit_gpu_sample,
+    :sp2d_varying,
+    :joint2d_fixed,
+)
+
+function _profile_size(profile::Symbol)
+    haskey(PROFILE_SIZES, profile) ||
+        error("profile must be one of $(collect(keys(PROFILE_SIZES))); got $profile")
+    return PROFILE_SIZES[profile]
 end
 
-function _resolve_sizes(profile::Symbol)
-    if haskey(ENV, "BATCH_N") || haskey(ENV, "BATCH_B")
-        return parse(Int, get(ENV, "BATCH_N", "512")), parse(Int, get(ENV, "BATCH_B", "16"))
+function _resolve_gpu_backend(backend)
+    if backend !== nothing
+        backend isa SFC.GPUBackend && return backend, backend.backend
+        return SFC.GPUBackend(backend), backend
     end
-    sz = _PROFILE_SIZES[profile]
-    return sz.N, sz.B
-end
-
-function _resolve_gpu_backend()
     if CUDA.functional()
-        be = CUDA.CUDABackend()
+        ka_backend = CUDA.CUDABackend()
         println("backend: CUDA ($(CUDA.name(CUDA.device())))")
-        return SFC.GPUBackend(be), be
+        return SFC.GPUBackend(ka_backend), ka_backend
     end
+    ka_backend = KA.CPU()
     println("backend: KA.CPU (CUDA not functional)")
-    return SFC.GPUBackend(KA.CPU()), KA.CPU()
+    return SFC.GPUBackend(ka_backend), ka_backend
 end
 
 function _bench_row(label::String, f::Function, ka_backend; warmup::Int = 1)
@@ -67,42 +94,238 @@ function _bench_row(label::String, f::Function, ka_backend; warmup::Int = 1)
     return elapsed
 end
 
-"""Sampled slice baseline: time `n_sample` slices, extrapolate to full B."""
-function _bench_slice_sampled(label::String, B::Int, n_sample::Int, f_slice::Function, ka_backend)
-    n_sample = min(n_sample, B)
-    idx = round.(Int, range(1, B; length = n_sample))
-    t_sample = _bench_row(
-        "$label (sample $n_sample / B=$B)",
-        () -> begin
-            for b in idx
-                f_slice(b)
-            end
-        end,
-        ka_backend,
-    )
-    t_extrap = t_sample * (B / n_sample)
-    @printf("    extrapolated full B: %.1f s (%.1f min)\n", t_extrap, t_extrap / 60)
-    return t_sample, t_extrap
+function _stage_for_backend(ka_backend, a)
+    ka_backend isa CUDA.CUDABackend && return CUDA.CuArray(a)
+    return a
 end
 
-function main()
-    profile = _resolve_profile()
-    N, B = _resolve_sizes(profile)
+function _sample_indices(B::Int, n_sample::Int)
+    n_sample = clamp(n_sample, 1, B)
+    n_sample == 1 && return [1]
+    return unique(round.(Int, range(1, B; length = n_sample)))
+end
+
+function _sample_batch(a, idx)
+    return @views copy(a[:, :, idx])
+end
+
+function _bench_explicit_gpu_shared_loop(
+    label::String,
+    sf,
+    ka_backend,
+    x,
+    u,
+    edges,
+    sample_indices;
+    warmup::Int,
+    extrapolate::Bool,
+)
+    xd = _stage_for_backend(ka_backend, x)
+    ud = _stage_for_backend(ka_backend, u)
+    B = size(u, 3)
+    n_sample = length(sample_indices)
+    elapsed = _bench_row(
+        label,
+        () -> begin
+            @views for b in sample_indices
+                SFC.gpu_calculate_structure_function(
+                    sf, ka_backend, xd, ud[:, :, b], edges;
+                    return_sums_and_counts = true,
+                )
+            end
+        end,
+        ka_backend;
+        warmup = warmup,
+    )
+    if extrapolate
+        full_estimate = elapsed * B / n_sample
+        @printf("    explicit GPU loop estimate for full B: %.1f s (%.1f min)\n",
+            full_estimate, full_estimate / 60)
+    end
+    return elapsed
+end
+
+function _bench_explicit_gpu_shared_loop_full(
+    sf,
+    ka_backend,
+    x,
+    u,
+    edges;
+    warmup::Int,
+)
+    return _bench_explicit_gpu_shared_loop(
+        "individual 1D fixed-x explicit GPU slice loop (full B)",
+        sf,
+        ka_backend,
+        x,
+        u,
+        edges,
+        axes(u, 3);
+        warmup = warmup,
+        extrapolate = false,
+    )
+end
+
+function _bench_explicit_gpu_varying_sf_loop(
+    label::String,
+    sf,
+    ka_backend,
+    x,
+    u,
+    edges,
+    sample_indices;
+    warmup::Int,
+    extrapolate::Bool,
+)
+    xd = _stage_for_backend(ka_backend, x)
+    ud = _stage_for_backend(ka_backend, u)
+    B = size(u, 3)
+    n_sample = length(sample_indices)
+    elapsed = _bench_row(
+        label,
+        () -> begin
+            @views for b in sample_indices
+                SFC.gpu_calculate_structure_function(
+                    sf, ka_backend, xd[:, :, b], ud[:, :, b], edges;
+                    return_sums_and_counts = true,
+                )
+            end
+        end,
+        ka_backend;
+        warmup = warmup,
+    )
+    if extrapolate
+        full_estimate = elapsed * B / n_sample
+        @printf("    explicit optimized GPU SF loop estimate for full B: %.1f s (%.1f min)\n",
+            full_estimate, full_estimate / 60)
+    end
+    return elapsed
+end
+
+function _bench_explicit_gpu_varying_sp1d_loop(
+    label::String,
+    gpu_backend,
+    ka_backend,
+    x,
+    u,
+    edges,
+    sample_indices;
+    warmup::Int,
+    extrapolate::Bool,
+)
+    xd = _stage_for_backend(ka_backend, x)
+    ud = _stage_for_backend(ka_backend, u)
+    B = size(u, 3)
+    n_sample = length(sample_indices)
+    elapsed = _bench_row(
+        label,
+        () -> begin
+            @views for b in sample_indices
+                SFC.calculate_structure_functions_single_pass(
+                    xd[:, :, b], ud[:, :, b], edges; backend = gpu_backend,
+                )
+            end
+        end,
+        ka_backend;
+        warmup = warmup,
+    )
+    if extrapolate
+        full_estimate = elapsed * B / n_sample
+        @printf("    explicit optimized GPU SP1D loop estimate for full B: %.1f s (%.1f min)\n",
+            full_estimate, full_estimate / 60)
+    end
+    return elapsed
+end
+
+function _bench_explicit_gpu_varying_sp2d_loop(
+    label::String,
+    gpu_backend,
+    ka_backend,
+    x,
+    u,
+    edges,
+    value_edges,
+    sample_indices;
+    warmup::Int,
+    extrapolate::Bool,
+)
+    xd = _stage_for_backend(ka_backend, x)
+    ud = _stage_for_backend(ka_backend, u)
+    B = size(u, 3)
+    n_sample = length(sample_indices)
+    elapsed = _bench_row(
+        label,
+        () -> begin
+            @views for b in sample_indices
+                SFC.calculate_structure_functions_single_pass_2d(
+                    xd[:, :, b], ud[:, :, b], edges, value_edges; backend = gpu_backend,
+                )
+            end
+        end,
+        ka_backend;
+        warmup = warmup,
+    )
+    if extrapolate
+        full_estimate = elapsed * B / n_sample
+        @printf("    explicit optimized GPU SP2D loop estimate for full B: %.1f s (%.1f min)\n",
+            full_estimate, full_estimate / 60)
+    end
+    return elapsed
+end
+
+function _parse_cases(raw::AbstractString)
+    isempty(strip(raw)) && return DEFAULT_CASES
+    raw == "all" && return ALL_CASES
+    return Tuple(Symbol(strip(part)) for part in split(raw, ",") if !isempty(strip(part)))
+end
+
+"""
+    run_batch_matrix_benchmark(; kwargs...)
+
+Run the maintained auxiliary-axis GPU benchmark matrix.
+
+Keyword controls:
+
+- `profile`: `:quick`, `:scaled`, or `:reference`.
+- `N`, `B`: override the profile sizes.
+- `n_dist`, `n_val`: distance/value bin counts.
+- `cases`: tuple of case symbols. Use `ALL_CASES` for the full matrix.
+- `explicit_samples`: number of slices for `:individual_fixed_gpu_sample`.
+- `allow_slow`: required for large `N` or `B`.
+- `backend`: optional KA backend, usually left as CUDA auto-detection.
+
+The default reference cases intentionally exclude the slow varying-position SP1D/SP2D
+full-B slice routes. They include sampled varying-position SP1D/SP2D routes with an
+extrapolated full-B estimate. Add `:sp1d_varying` or `:sp2d_varying` explicitly only
+when measuring the full route.
+"""
+function run_batch_matrix_benchmark(;
+    profile::Symbol = :quick,
+    N::Union{Nothing, Int} = nothing,
+    B::Union{Nothing, Int} = nothing,
+    n_dist::Int = 16,
+    n_val::Int = 8,
+    cases = DEFAULT_CASES,
+    explicit_samples::Int = profile === :reference ? 8 : 4,
+    warmup::Int = 1,
+    allow_slow::Bool = false,
+    backend = nothing,
+    seed::Int = 1,
+)
+    sz = _profile_size(profile)
+    N = something(N, sz.N)
+    B = something(B, sz.B)
     large = N >= 4096 || B >= 512
-    if large && get(ENV, "ALLOW_SLOW", "0") != "1"
+    if large && !allow_slow
         error(
-            "Refusing large benchmark (N=$N B=$B profile=$profile) without ALLOW_SLOW=1. " *
-            "Use PROFILE=quick for dev (~1–2 min), or PROFILE=scaled (~5 min).",
+            "Refusing large benchmark (N=$N B=$B profile=$profile) without allow_slow=true. " *
+            "Use profile=:quick for dev, or pass allow_slow=true deliberately.",
         )
     end
+    unknown = setdiff(Symbol.(cases), ALL_CASES)
+    isempty(unknown) || error("unknown benchmark cases: $unknown; valid cases are $(ALL_CASES)")
 
-    slice_mode = get(ENV, "SLICE_BASELINE", profile === :reference_full ? "full" : profile === :reference ? "sample" : "off")
-    prod_sample = parse(Int, get(ENV, "PROD_SAMPLE", profile === :reference ? "8" : "0"))
-    warmup = parse(Int, get(ENV, "BATCH_WARMUP", "1"))
-    n_dist = parse(Int, get(ENV, "N_DIST", "16"))
-    n_val = parse(Int, get(ENV, "N_VAL", "8"))
-
-    Random.seed!(1)
+    Random.seed!(seed)
     x_fix = rand(Float32, 2, N)
     u_fix = rand(Float32, 2, N, B)
     x_var = rand(Float32, 2, N, B)
@@ -110,82 +333,189 @@ function main()
     edges = LinearBinEdges(collect(range(0.0f0, 2.0f0; length = n_dist + 1)))
     val_edges = LinearBinEdges(collect(range(-1.0f0, 1.0f0; length = n_val + 1)))
     sf = SFT.L2SFType()
-    gpu_be, ka_backend = _resolve_gpu_backend()
+    gpu_backend, ka_backend = _resolve_gpu_backend(backend)
     NB = length(edges.edges) - 1
     nv = length(val_edges.edges) - 1
 
-    n_strips = cld(B, 16)
     n_tile_blocks = cld(N, 128) * (cld(N, 128) + 1) ÷ 2
     @printf(
-        "batch matrix PROFILE=%s N=%d B=%d n_dist=%d n_val=%d strips(1D)≈%d strips(SP1D)≈%d tile_blocks≈%d\n",
+        "batch matrix profile=%s N=%d B=%d n_dist=%d n_val=%d strips(1D)=%d strips(SP1D)=%d tile_blocks=%d (NB must be <= 127)\n",
         profile, N, B, n_dist, n_val, cld(B, 16), cld(B, 8), n_tile_blocks,
     )
-    println("cases: individual-1D-fixed | individual-1D-varying | SP1D-fixed | SP1D-varying | SP2D-fixed | SP2D-varying | joint2D-fixed")
+    println("cases: $(join(string.(cases), ", "))")
+    rows = Pair{Symbol, Float64}[]
 
-    _bench_row("individual 1D fixed-x (GPU batch)", () -> begin
-        SFC.calculate_structure_function(
-            sf, x_fix, u_fix, edges;
-            backend = gpu_be, return_sums_and_counts = true, verbose = false,
-        )
-    end, ka_backend; warmup = warmup)
-
-    if slice_mode == "full"
-        _bench_row("individual 1D fixed-x slice baseline (B×serial)", () -> begin
-            s = zeros(Float32, NB, B); c = zeros(UInt32, NB, B)
-            for b in 1:B
-                SFC.serial_calculate_structure_function!(
-                    @view(s[:, b]), @view(c[:, b]), sf, x_fix, u_fix[:, :, b], edges;
-                    verbose = false, show_progress = false,
-                )
-            end
-        end, ka_backend; warmup = warmup)
-    elseif slice_mode == "sample" && prod_sample > 0
-        _bench_slice_sampled(
-            "individual 1D fixed-x slice baseline", B, prod_sample,
-            b -> begin
-                s = zeros(Float32, NB); c = zeros(UInt32, NB)
-                SFC.serial_calculate_structure_function!(
-                    s, c, sf, x_fix, u_fix[:, :, b], edges;
-                    verbose = false, show_progress = false,
-                )
-            end,
-            ka_backend,
-        )
+    if :individual_fixed in cases
+        push!(rows, :individual_fixed => _bench_row("individual 1D fixed-x (GPU batch)", () -> begin
+            SFC.calculate_structure_function(
+                sf, x_fix, u_fix, edges;
+                backend = gpu_backend, return_sums_and_counts = true, verbose = false,
+            )
+        end, ka_backend; warmup = warmup))
     end
 
-    _bench_row("individual 1D varying-x (GPU slices)", () -> begin
-        s = zeros(Float32, NB, B); c = zeros(UInt32, NB, B)
-        SFC.calculate_structure_function_slices!(s, c, sf, x_var, u_var, edges; backend = gpu_be)
-    end, ka_backend; warmup = warmup)
+    if :individual_fixed_gpu_sample in cases
+        idx = _sample_indices(B, explicit_samples)
+        label = "individual 1D fixed-x explicit GPU slice loop (sample $(length(idx)) / B=$B)"
+        push!(rows, :individual_fixed_gpu_sample => _bench_explicit_gpu_shared_loop(
+            label, sf, ka_backend, x_fix, u_fix, edges, idx;
+            warmup = warmup,
+            extrapolate = true,
+        ))
+    end
 
-    _bench_row("SP1D six-type fixed-x (GPU batch)", () -> begin
-        SFC.calculate_structure_functions_single_pass(x_fix, u_fix, edges; backend = gpu_be)
-    end, ka_backend; warmup = warmup)
+    if :individual_fixed_gpu_full in cases
+        push!(rows, :individual_fixed_gpu_full => _bench_explicit_gpu_shared_loop_full(
+            sf, ka_backend, x_fix, u_fix, edges; warmup = warmup,
+        ))
+    end
 
-    _bench_row("SP1D six-type varying-x (GPU slices)", () -> begin
-        s = zeros(Float32, 6, NB, B); c = zeros(UInt32, 6, NB, B)
-        SFC.calculate_structure_functions_single_pass_slices!(s, c, x_var, u_var, edges; backend = gpu_be)
-    end, ka_backend; warmup = warmup)
+    if :individual_varying in cases
+        push!(rows, :individual_varying => _bench_row("individual 1D varying-x (GPU slices)", () -> begin
+            s = zeros(Float32, NB, B)
+            c = zeros(UInt32, NB, B)
+            SFC.calculate_structure_function_slices!(s, c, sf, x_var, u_var, edges; backend = gpu_backend)
+        end, ka_backend; warmup = warmup))
+    end
 
-    _bench_row("SP2D six-type fixed-x (GPU batch)", () -> begin
-        SFC.calculate_structure_functions_single_pass_2d(x_fix, u_fix, edges, val_edges; backend = gpu_be)
-    end, ka_backend; warmup = warmup)
+    if :individual_varying_explicit_gpu_sample in cases
+        idx = _sample_indices(B, explicit_samples)
+        label = "individual 1D varying-x explicit optimized GPU loop (sample $(length(idx)) / B=$B)"
+        push!(rows, :individual_varying_explicit_gpu_sample => _bench_explicit_gpu_varying_sf_loop(
+            label, sf, ka_backend, x_var, u_var, edges, idx;
+            warmup = warmup,
+            extrapolate = true,
+        ))
+    end
 
-    _bench_row("SP2D six-type varying-x (GPU slices)", () -> begin
-        s = zeros(Float32, 6, NB, nv, B); c = zeros(UInt32, 6, NB, nv, B)
-        SFC.calculate_structure_functions_single_pass_2d_slices!(
-            s, c, x_var, u_var, edges, val_edges; backend = gpu_be,
+    if :sp1d_fixed in cases
+        push!(rows, :sp1d_fixed => _bench_row("SP1D six-invariant fixed-x (GPU batch)", () -> begin
+            SFC.calculate_structure_functions_single_pass(x_fix, u_fix, edges; backend = gpu_backend)
+        end, ka_backend; warmup = warmup))
+    end
+
+    if :sp1d_varying_gpu_sample in cases
+        idx = _sample_indices(B, explicit_samples)
+        x_sample = _sample_batch(x_var, idx)
+        u_sample = _sample_batch(u_var, idx)
+        B_sample = length(idx)
+        elapsed = _bench_row(
+            "SP1D six-invariant varying-x (GPU slices sample $B_sample / B=$B)",
+            () -> begin
+                s = zeros(Float32, 6, NB, B_sample)
+                c = zeros(UInt32, 6, NB, B_sample)
+                SFC.calculate_structure_functions_single_pass_slices!(
+                    s, c, x_sample, u_sample, edges; backend = gpu_backend,
+                )
+            end,
+            ka_backend;
+            warmup = warmup,
         )
-    end, ka_backend; warmup = warmup)
+        full_estimate = elapsed * B / B_sample
+        @printf("    varying SP1D estimate for full B: %.1f s (%.1f min)\n",
+            full_estimate, full_estimate / 60)
+        push!(rows, :sp1d_varying_gpu_sample => elapsed)
+    end
 
-    _bench_row("joint 2D single-type fixed-x (GPU batch)", () -> begin
-        SFC.calculate_structure_function(
-            sf, x_fix, u_fix, edges, val_edges;
-            backend = gpu_be, return_sums_and_counts = true, verbose = false,
+    if :sp1d_varying_explicit_gpu_sample in cases
+        idx = _sample_indices(B, explicit_samples)
+        label = "SP1D varying-x explicit optimized GPU loop (sample $(length(idx)) / B=$B)"
+        push!(rows, :sp1d_varying_explicit_gpu_sample => _bench_explicit_gpu_varying_sp1d_loop(
+            label, gpu_backend, ka_backend, x_var, u_var, edges, idx;
+            warmup = warmup,
+            extrapolate = true,
+        ))
+    end
+
+    if :sp1d_varying in cases
+        push!(rows, :sp1d_varying => _bench_row("SP1D six-invariant varying-x (GPU slices full B)", () -> begin
+            s = zeros(Float32, 6, NB, B)
+            c = zeros(UInt32, 6, NB, B)
+            SFC.calculate_structure_functions_single_pass_slices!(s, c, x_var, u_var, edges; backend = gpu_backend)
+        end, ka_backend; warmup = warmup))
+    end
+
+    if :sp2d_fixed in cases
+        push!(rows, :sp2d_fixed => _bench_row("SP2D six-invariant fixed-x (GPU batch)", () -> begin
+            SFC.calculate_structure_functions_single_pass_2d(x_fix, u_fix, edges, val_edges; backend = gpu_backend)
+        end, ka_backend; warmup = warmup))
+    end
+
+    if :sp2d_varying_gpu_sample in cases
+        idx = _sample_indices(B, explicit_samples)
+        x_sample = _sample_batch(x_var, idx)
+        u_sample = _sample_batch(u_var, idx)
+        B_sample = length(idx)
+        elapsed = _bench_row(
+            "SP2D six-invariant varying-x (GPU slices sample $B_sample / B=$B)",
+            () -> begin
+                s = zeros(Float32, 6, NB, nv, B_sample)
+                c = zeros(UInt32, 6, NB, nv, B_sample)
+                SFC.calculate_structure_functions_single_pass_2d_slices!(
+                    s, c, x_sample, u_sample, edges, val_edges; backend = gpu_backend,
+                )
+            end,
+            ka_backend;
+            warmup = warmup,
         )
-    end, ka_backend; warmup = warmup)
+        full_estimate = elapsed * B / B_sample
+        @printf("    varying SP2D estimate for full B: %.1f s (%.1f min)\n",
+            full_estimate, full_estimate / 60)
+        push!(rows, :sp2d_varying_gpu_sample => elapsed)
+    end
+
+    if :sp2d_varying_explicit_gpu_sample in cases
+        idx = _sample_indices(B, explicit_samples)
+        label = "SP2D varying-x explicit optimized GPU loop (sample $(length(idx)) / B=$B)"
+        push!(rows, :sp2d_varying_explicit_gpu_sample => _bench_explicit_gpu_varying_sp2d_loop(
+            label, gpu_backend, ka_backend, x_var, u_var, edges, val_edges, idx;
+            warmup = warmup,
+            extrapolate = true,
+        ))
+    end
+
+    if :sp2d_varying in cases
+        push!(rows, :sp2d_varying => _bench_row("SP2D six-invariant varying-x (GPU slices full B)", () -> begin
+            s = zeros(Float32, 6, NB, nv, B)
+            c = zeros(UInt32, 6, NB, nv, B)
+            SFC.calculate_structure_functions_single_pass_2d_slices!(
+                s, c, x_var, u_var, edges, val_edges; backend = gpu_backend,
+            )
+        end, ka_backend; warmup = warmup))
+    end
+
+    if :joint2d_fixed in cases
+        push!(rows, :joint2d_fixed => _bench_row("joint 2D single-type fixed-x (GPU batch)", () -> begin
+            SFC.calculate_structure_function(
+                sf, x_fix, u_fix, edges, val_edges;
+                backend = gpu_backend, return_sums_and_counts = true, verbose = false,
+            )
+        end, ka_backend; warmup = warmup))
+    end
 
     println("done.")
+    return (; profile, N, B, n_dist, n_val, cases = Tuple(cases), rows = Dict(rows))
 end
 
-main()
+function main()
+    profile = Symbol(lowercase(strip(get(ENV, "PROFILE", "quick"))))
+    sizes = _profile_size(profile)
+    N = parse(Int, get(ENV, "BATCH_N", string(sizes.N)))
+    B = parse(Int, get(ENV, "BATCH_B", string(sizes.B)))
+    cases = _parse_cases(get(ENV, "CASES", join(string.(DEFAULT_CASES), ",")))
+    return run_batch_matrix_benchmark(;
+        profile,
+        N,
+        B,
+        n_dist = parse(Int, get(ENV, "N_DIST", "16")),
+        n_val = parse(Int, get(ENV, "N_VAL", "8")),
+        cases,
+        explicit_samples = parse(Int, get(ENV, "EXPLICIT_SAMPLES", profile === :reference ? "8" : "4")),
+        warmup = parse(Int, get(ENV, "BATCH_WARMUP", "1")),
+        allow_slow = get(ENV, "ALLOW_SLOW", "0") == "1",
+    )
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/gpu/benchmark_results/README.md
+++ b/gpu/benchmark_results/README.md
@@ -1,6 +1,7 @@
 # GPU benchmark results
 
-Generated benchmark JSON lives here. Keep profiler dumps, local logs, and ad hoc
+Generated benchmark JSON lives here. **Working perf notes:** `BATCH_FIXED_X_PERF.md`.
+Keep profiler dumps, local logs, and ad hoc
 database outputs out of the repository; only commit intentional, reproducible result
 snapshots.
 

--- a/gpu/run_bench_1d.sh
+++ b/gpu/run_bench_1d.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=sf_b1d
+#SBATCH --output=gpu/benchmark_results/bench_1d_%j.out
+#SBATCH --error=gpu/benchmark_results/bench_1d_%j.out
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=00:20:00
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$(pwd)}"; mkdir -p gpu/benchmark_results
+echo "host=$(hostname) job=${SLURM_JOB_ID:-local}"; nvidia-smi --query-gpu=name --format=csv,noheader | head -1 || true
+"${JULIA:-julia}" --project=gpu gpu/bench_1d_old_vs_nbody.jl

--- a/gpu/run_cuda_1d_parity.sh
+++ b/gpu/run_cuda_1d_parity.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=sf_cuda1d
+#SBATCH --output=gpu/benchmark_results/cuda1d_parity_%j.out
+#SBATCH --error=gpu/benchmark_results/cuda1d_parity_%j.out
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=00:20:00
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$(pwd)}"; mkdir -p gpu/benchmark_results
+echo "host=$(hostname) job=${SLURM_JOB_ID:-local}"; nvidia-smi --query-gpu=name --format=csv,noheader | head -1 || true
+"${JULIA:-julia}" --project=gpu gpu/test_cuda_1d_parity.jl

--- a/gpu/run_cuda_2d_parity.sh
+++ b/gpu/run_cuda_2d_parity.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=sf_cuda2d
+#SBATCH --output=gpu/benchmark_results/cuda2d_parity_%j.out
+#SBATCH --error=gpu/benchmark_results/cuda2d_parity_%j.out
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=00:20:00
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$(pwd)}"; mkdir -p gpu/benchmark_results
+echo "host=$(hostname) job=${SLURM_JOB_ID:-local}"; nvidia-smi --query-gpu=name --format=csv,noheader || true
+"${JULIA:-julia}" --project=gpu gpu/test_cuda_2d_parity.jl

--- a/gpu/run_e2e_2d_cuda.sh
+++ b/gpu/run_e2e_2d_cuda.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=sf_e2e2d
+#SBATCH --output=gpu/benchmark_results/e2e_2d_%j.out
+#SBATCH --error=gpu/benchmark_results/e2e_2d_%j.out
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=00:20:00
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$(pwd)}"; mkdir -p gpu/benchmark_results
+echo "host=$(hostname) job=${SLURM_JOB_ID:-local}"; nvidia-smi --query-gpu=name --format=csv,noheader | head -1 || true
+"${JULIA:-julia}" --project=gpu gpu/test_e2e_2d_cuda.jl

--- a/gpu/run_slices_e2e.sh
+++ b/gpu/run_slices_e2e.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=sf_slices
+#SBATCH --output=gpu/benchmark_results/slices_e2e_%j.out
+#SBATCH --error=gpu/benchmark_results/slices_e2e_%j.out
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=00:20:00
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$(pwd)}"; mkdir -p gpu/benchmark_results
+echo "host=$(hostname) job=${SLURM_JOB_ID:-local}"; nvidia-smi --query-gpu=name --format=csv,noheader | head -1 || true
+"${JULIA:-julia}" --project=gpu gpu/test_slices_e2e.jl

--- a/gpu/test_cuda_1d_parity.jl
+++ b/gpu/test_cuda_1d_parity.jl
@@ -1,0 +1,88 @@
+# =============================================================================
+# Parity + timing for the CUDA fast 1D kernel (N-body broadcast, static-shared
+# privatized histogram, TILE=256) vs the KA unified kernel on KA.CPU(). Also
+# re-checks the joint2d-varying GPU↔CPU count diff is FP-boundary (few pairs),
+# not systematic.
+#   julia --project=gpu gpu/test_cuda_1d_parity.jl
+# =============================================================================
+using StructureFunctions
+import KernelAbstractions as KA
+using CUDA, StaticArrays, Printf
+using Statistics: median
+const SF = StructureFunctions
+const SFC = SF.Calculations
+const GE = Base.get_extension(SF, :StructureFunctionsGPUExt)
+const SFT = SF.StructureFunctionTypes
+const FT = Float32
+const N = parse(Int, get(ENV, "SF_T_N", "3000"))
+const B = parse(Int, get(ENV, "SF_T_B", "8"))
+const D = 2
+const sf2 = SFT.L2SFType()
+
+function ref_1d(x, u, dig, N, NB, B, NMOM, fixed_x)
+    out = zeros(FT, NMOM, NB, B); cnt = zeros(UInt32, NMOM, NB, B)
+    GE._sf_launch_1d_batch!(KA.CPU(), out, cnt, x, u, sf2, dig, N, NB, B, D, Val(NMOM), fixed_x)
+    KA.synchronize(KA.CPU())
+    return out, cnt
+end
+function cuda_1d(xd, ud, dig, N, NB, B, NMOM, fixed_x)
+    out = CUDA.zeros(FT, NMOM, NB, B); cnt = CUDA.zeros(UInt32, NMOM, NB, B)
+    h = SFC.gpu_fast_launch_1d_batch!(CUDA.CUDABackend(), out, cnt, xd, ud, sf2, dig, N, NB, B, D, NMOM, fixed_x)
+    CUDA.synchronize()
+    return Array(out), Array(cnt), h
+end
+
+println("CUDA 1D fast-kernel parity vs KA.CPU() — N=$N B=$B D=$D\n")
+println("| NMOM | fixed_x | NB | handled | max relΔ | max |Δcount| |")
+for NMOM in (1, 6), fixed_x in (true, false), NB in (16, 50, 128)
+    x_h = fixed_x ? rand(FT, D, N) : rand(FT, D, N, B)
+    u_h = randn(FT, D, N, B)
+    dist_bins = collect(FT, range(0.05f0, 2.0f0, length = NB + 1))
+    dig_c = GE._sf_batch_dist_digitizer(KA.CPU(), dist_bins)
+    dig_g = GE._sf_batch_dist_digitizer(CUDA.CUDABackend(), dist_bins)
+    o_ref, c_ref = ref_1d(x_h, u_h, dig_c, N, NB, B, NMOM, fixed_x)
+    o_cu, c_cu, h = cuda_1d(CuArray(x_h), CuArray(u_h), dig_g, N, NB, B, NMOM, fixed_x)
+    rel = maximum(abs.(o_cu .- o_ref) ./ max.(abs.(o_ref), 1f-3))
+    dcnt = maximum(abs.(Int.(c_cu) .- Int.(c_ref)))
+    @printf("| %d | %s | %d | %s | %.2e | %d |\n", NMOM, fixed_x, NB, h, rel, dcnt)
+end
+
+# ---- timing: SP1D NB=50 & individual NB=50, fixed-x, real N=20000 ----
+println("\n--- timing 1D fixed-x N=20000 (kernel, extrapolate to B=8064) ---")
+let Nt = 20000, Bt = 64, NB = 50
+    x_h = rand(FT, D, Nt); u_h = randn(FT, D, Nt, Bt)
+    dist_bins = collect(FT, range(0.05f0, 2.0f0, length = NB + 1))
+    dig = GE._sf_batch_dist_digitizer(CUDA.CUDABackend(), dist_bins)
+    xd = CuArray(x_h); ud = CuArray(u_h)
+    for NMOM in (1, 6)
+        out = CUDA.zeros(FT, NMOM, NB, Bt); cnt = CUDA.zeros(UInt32, NMOM, NB, Bt)
+        f() = (CUDA.fill!(out, 0f0); CUDA.fill!(cnt, UInt32(0));
+               SFC.gpu_fast_launch_1d_batch!(CUDA.CUDABackend(), out, cnt, xd, ud, sf2, dig, Nt, NB, Bt, D, NMOM, true);
+               CUDA.synchronize())
+        f(); f(); ts = Float64[]; for _ in 1:5; t = time_ns(); f(); push!(ts, (time_ns()-t)/1e9); end
+        t = median(ts); bapps = (Nt*(Nt-1)/2)*Bt/t/1e9
+        @printf("  NMOM=%d NB=%d: %.4f s  (%.1f bapps)  → B=8064 ≈ %.1f s\n", NMOM, NB, t, bapps, t*8064/Bt)
+    end
+end
+
+# ---- joint2d-varying FP-boundary recheck: CUDA vs KA-CPU 2D, NMOM=1 varying ----
+println("\n--- joint2d-varying CUDA vs KA-CPU count diff (expect few pairs) ---")
+let Nj = 3000, Bj = 6, nd = 20, nv = 20
+    for seed_shift in (0.0f0, 0.137f0)
+        x_h = rand(FT, D, Nj, Bj) .+ seed_shift; u_h = randn(FT, D, Nj, Bj)
+        db = collect(FT, range(0.05f0, 2.0f0, length = nd + 1))
+        vb = collect(FT, range(-5f0, 5f0, length = nv + 1))
+        ddig_c = GE._sf_batch_dist_digitizer(KA.CPU(), db); vpc = GE._gpu_build_value_digitize_plan(KA.CPU(), vb)
+        ddig_g = GE._sf_batch_dist_digitizer(CUDA.CUDABackend(), db); vpg = GE._gpu_build_value_digitize_plan(CUDA.CUDABackend(), vb)
+        oc = zeros(FT, 1, nd, nv, Bj); cc = zeros(UInt32, 1, nd, nv, Bj)
+        GE._sf_launch_2d_batch!(KA.CPU(), oc, cc, x_h, u_h, sf2, ddig_c, vpc, Nj, nd, nv, Bj, D, Val(1), false)
+        KA.synchronize(KA.CPU())
+        og = CUDA.zeros(FT, 1, nd, nv, Bj); cg = CUDA.zeros(UInt32, 1, nd, nv, Bj)
+        GE._sf_launch_2d_batch!(CUDA.CUDABackend(), og, cg, CuArray(x_h), CuArray(u_h), sf2, ddig_g, vpg, Nj, nd, nv, Bj, D, Val(1), false)
+        CUDA.synchronize()
+        dcnt = maximum(abs.(Int.(Array(cg)) .- Int.(cc)))
+        tot = sum(cc)
+        @printf("  seed_shift=%.3f: max|Δcount|=%d  total_pairs=%d  (%.1e fraction)\n", seed_shift, dcnt, tot, dcnt/tot)
+    end
+end
+println("\nDONE_1D")

--- a/gpu/test_cuda_2d_parity.jl
+++ b/gpu/test_cuda_2d_parity.jl
@@ -1,0 +1,86 @@
+# =============================================================================
+# Parity + timing for the CUDA fast 2D kernel (StructureFunctionsCUDAExt) vs the
+# portable KA unified kernel run on KA.CPU() (the validated reference). Exercises
+# the kernel through the same chokepoint the public API uses (_sf_launch_2d_batch!),
+# for NMOM ∈ {1 (joint), 6 (single-pass)} × fixed/varying × bin sizes.
+#   julia --project=gpu gpu/test_cuda_2d_parity.jl
+# =============================================================================
+using StructureFunctions
+import KernelAbstractions as KA
+using CUDA, StaticArrays, Printf
+using Statistics: median
+const SF = StructureFunctions
+const SFC = SF.Calculations
+const GE = Base.get_extension(SF, :StructureFunctionsGPUExt)
+const SFT = SF.StructureFunctionTypes
+const FT = Float32
+
+const N = parse(Int, get(ENV, "SF_T_N", "3000"))
+const B = parse(Int, get(ENV, "SF_T_B", "8"))
+const D = 2
+const sf2 = SFT.SecondOrderStructureFunctionType()
+
+# Reference: force the KA path on CPU (default hook returns false → KA unified).
+function ka_cpu_2d(x, u, ddig_cpu, vplan_cpu, N, n_dist, n_val, B, NMOM, fixed_x)
+    out = zeros(FT, NMOM, n_dist, n_val, B)
+    cnt = zeros(UInt32, NMOM, n_dist, n_val, B)
+    GE._sf_launch_2d_batch!(KA.CPU(), out, cnt, x, u, sf2, ddig_cpu, vplan_cpu,
+                            N, n_dist, n_val, B, D, Val(NMOM), fixed_x)
+    KA.synchronize(KA.CPU())
+    return out, cnt
+end
+
+function cuda_2d(xd, ud, ddig, vplan, N, n_dist, n_val, B, NMOM, fixed_x)
+    out = CUDA.zeros(FT, NMOM, n_dist, n_val, B)
+    cnt = CUDA.zeros(UInt32, NMOM, n_dist, n_val, B)
+    handled = SFC.gpu_fast_launch_2d_batch!(CUDA.CUDABackend(), out, cnt, xd, ud, sf2, ddig, vplan,
+                                            N, n_dist, n_val, B, D, NMOM, fixed_x)
+    CUDA.synchronize()
+    return out, cnt, handled
+end
+
+println("CUDA 2D fast-kernel parity vs KA.CPU() reference — N=$N B=$B D=$D\n")
+println("| NMOM | fixed_x | bins | handled | max relΔ sums | counts exact | TILE-fit |")
+for NMOM in (1, 6)
+    for fixed_x in (true, false)
+        for (n_dist, n_val) in ((16, 8), (20, 20), (50, 50))
+            x_h = fixed_x ? rand(FT, D, N) : rand(FT, D, N, B)
+            u_h = randn(FT, D, N, B)
+            dist_bins = collect(FT, range(0.05f0, 2.0f0, length = n_dist + 1))
+            vb = collect(FT, range(-5.0f0, 5.0f0, length = n_val + 1))
+            ddig_cpu = GE._sf_batch_dist_digitizer(KA.CPU(), dist_bins)
+            vplan_cpu = GE._gpu_build_value_digitize_plan(KA.CPU(), vb)
+            ddig = GE._sf_batch_dist_digitizer(CUDA.CUDABackend(), dist_bins)
+            vplan = GE._gpu_build_value_digitize_plan(CUDA.CUDABackend(), vb)
+            xd = fixed_x ? CuArray(x_h) : CuArray(x_h)
+            ud = CuArray(u_h)
+
+            o_ref, c_ref = ka_cpu_2d(x_h, u_h, ddig_cpu, vplan_cpu, N, n_dist, n_val, B, NMOM, fixed_x)
+            o_cu, c_cu, handled = cuda_2d(xd, ud, ddig, vplan, N, n_dist, n_val, B, NMOM, fixed_x)
+            oc = Array(o_cu); cc = Array(c_cu)
+            rel = maximum(abs.(oc .- o_ref) ./ max.(abs.(o_ref), 1f-3))
+            cexact = cc == c_ref
+            @printf("| %d | %s | %dx%d | %s | %.2e | %s | %s |\n",
+                    NMOM, fixed_x, n_dist, n_val, handled, rel, cexact, handled)
+        end
+    end
+end
+
+# ---- timing the user's headline case: SP2D 50x50, fixed-x, at this B ----
+println("\n--- timing SP2D 50x50 fixed-x (extrapolate to B=8064) ---")
+let n_dist = 50, n_val = 50, NMOM = 6, fixed_x = true
+    x_h = rand(FT, D, N); u_h = randn(FT, D, N, B)
+    dist_bins = collect(FT, range(0.05f0, 2.0f0, length = n_dist + 1))
+    vb = collect(FT, range(-5.0f0, 5.0f0, length = n_val + 1))
+    ddig = GE._sf_batch_dist_digitizer(CUDA.CUDABackend(), dist_bins)
+    vplan = GE._gpu_build_value_digitize_plan(CUDA.CUDABackend(), vb)
+    xd = CuArray(x_h); ud = CuArray(u_h)
+    out = CUDA.zeros(FT, NMOM, n_dist, n_val, B); cnt = CUDA.zeros(UInt32, NMOM, n_dist, n_val, B)
+    f() = (CUDA.fill!(out, 0f0); CUDA.fill!(cnt, UInt32(0));
+           GE._sf_launch_2d_batch!(CUDA.CUDABackend(), out, cnt, xd, ud, sf2, ddig, vplan,
+                                   N, n_dist, n_val, B, D, Val(6), true); CUDA.synchronize())
+    f(); f(); ts = Float64[]; for _ in 1:5; t = time_ns(); f(); push!(ts, (time_ns()-t)/1e9); end
+    t = median(ts); bapps = (N*(N-1)/2)*B/t/1e9
+    @printf("  N=%d B=%d: %.3f s  (%.2f bapps)  → B=8064 ≈ %.1f s\n", N, B, t, bapps, t*8064/B)
+end
+println("\nDONE_PARITY")

--- a/gpu/test_e2e_2d_cuda.jl
+++ b/gpu/test_e2e_2d_cuda.jl
@@ -1,0 +1,79 @@
+# =============================================================================
+# End-to-end validation of the 2D CUDA fast path THROUGH THE PUBLIC API on a
+# real CUDABackend: SP2D (fixed + varying) and joint 2D (fixed + varying) vs the
+# serial CPU reference, plus headline real-N (20000) SP2D 50x50 wall-clock.
+#   julia --project=gpu gpu/test_e2e_2d_cuda.jl
+# =============================================================================
+using StructureFunctions
+import KernelAbstractions as KA
+using CUDA, Printf
+using Statistics: median
+const SF = StructureFunctions
+const SFC = SF.Calculations
+const SFT = SF.StructureFunctionTypes
+using StructureFunctions: LinearBinEdges
+using StructureFunctions.Calculations:
+    serial_calculate_structure_functions_single_pass_2d!, auxiliary_joint2d!
+const FT = Float32
+const GPU_BE = SFC.GPUBackend(CUDA.CUDABackend())
+const SF_TYPE = SFT.L2SFType()
+
+maxrel(a, b) = maximum(abs.(a .- b) ./ max.(abs.(b), 1f-3))
+
+println("End-to-end 2D CUDA public-API parity vs serial CPU\n")
+println("| case | bins | max relΔ | counts exact |")
+
+# ---- SP2D fixed-x ----
+let N = 1500, B = 4
+    for (nd, nv) in ((16, 8), (50, 50))
+        x = rand(FT, 2, N); u = randn(FT, 2, N, B)
+        lbe = LinearBinEdges(collect(range(0.0f0, 1.5f0; length = nd + 1)))
+        ve = LinearBinEdges(collect(range(-1.0f0, 1.0f0; length = nv + 1)))
+        cs = zeros(FT, 6, nd, nv, B); cc = zeros(UInt32, 6, nd, nv, B)
+        serial_calculate_structure_functions_single_pass_2d!(cs, cc, x, u, lbe, ve)
+        g = SFC.calculate_structure_functions_single_pass_2d(x, u, lbe, ve; backend = GPU_BE)
+        @printf("| SP2D fixed | %dx%d | %.2e | %s |\n", nd, nv, maxrel(g.sums, cs), g.counts == cc)
+    end
+end
+# ---- SP2D varying-x ----
+let N = 1500, B = 4
+    for (nd, nv) in ((20, 20),)
+        x = rand(FT, 2, N, B); u = randn(FT, 2, N, B)
+        lbe = LinearBinEdges(collect(range(0.0f0, 1.5f0; length = nd + 1)))
+        ve = LinearBinEdges(collect(range(-1.0f0, 1.0f0; length = nv + 1)))
+        cs = zeros(FT, 6, nd, nv, B); cc = zeros(UInt32, 6, nd, nv, B)
+        serial_calculate_structure_functions_single_pass_2d!(cs, cc, x, u, lbe, ve)
+        g = SFC.calculate_structure_functions_single_pass_2d(x, u, lbe, ve; backend = GPU_BE)
+        @printf("| SP2D varying | %dx%d | %.2e | %s |\n", nd, nv, maxrel(g.sums, cs), g.counts == cc)
+    end
+end
+# ---- joint 2D fixed-x and varying-x ----
+let N = 1500, B = 4
+    x = rand(FT, 2, N); u = randn(FT, 2, N, B)
+    lbe = LinearBinEdges(collect(range(0.0f0, 1.5f0; length = 21)))
+    ve = LinearBinEdges(collect(range(-0.5f0, 1.5f0; length = 21)))
+    cs = zeros(FT, 20, 20, B); cc = zeros(UInt32, 20, 20, B)
+    auxiliary_joint2d!(cs, cc, SF_TYPE, x, u, lbe, ve)
+    g = SFC.calculate_structure_function(SF_TYPE, x, u, lbe, ve; backend = GPU_BE)
+    @printf("| joint2d fixed | 20x20 | %.2e | %s |\n", maxrel(g.sums, cs), g.counts == cc)
+
+    xv = rand(FT, 2, N, B)
+    cs2 = zeros(FT, 20, 20, B); cc2 = zeros(UInt32, 20, 20, B)
+    auxiliary_joint2d!(cs2, cc2, SF_TYPE, xv, u, lbe, ve)
+    g2 = SFC.calculate_structure_function(SF_TYPE, xv, u, lbe, ve; backend = GPU_BE)
+    @printf("| joint2d varying | 20x20 | %.2e | %s |\n", maxrel(g2.sums, cs2), g2.counts == cc2)
+end
+
+# ---- headline timing: SP2D 50x50 fixed-x at real N=20000 (public API wall-clock) ----
+println("\n--- headline: SP2D 50x50 fixed-x, N=20000 (public API, wall-clock) ---")
+let N = 20000, B = 64, nd = 50, nv = 50
+    x = rand(FT, 2, N); u = randn(FT, 2, N, B)
+    lbe = LinearBinEdges(collect(range(0.0f0, 1.5f0; length = nd + 1)))
+    ve = LinearBinEdges(collect(range(-1.0f0, 1.0f0; length = nv + 1)))
+    f() = SFC.calculate_structure_functions_single_pass_2d(x, u, lbe, ve; backend = GPU_BE)
+    f(); f()
+    ts = Float64[]; for _ in 1:3; t = time_ns(); f(); push!(ts, (time_ns()-t)/1e9); end
+    t = median(ts); bapps = (N*(N-1)/2)*B/t/1e9
+    @printf("  N=%d B=%d: %.3f s  (%.2f bapps)  → B=8064 ≈ %.0f s\n", N, B, t, bapps, t*8064/B)
+end
+println("\nDONE_E2E")

--- a/gpu/test_slices_e2e.jl
+++ b/gpu/test_slices_e2e.jl
@@ -1,0 +1,73 @@
+# =============================================================================
+# End-to-end validation of the fused SLICES (time-series) paths on a real
+# CUDABackend vs the serial CPU reference: 1D individual, SP1D, joint2d, SP2D
+# slices over (D,N,T). Confirms the unified-N-body rewiring of the per-slice
+# loops is correct on GPU, plus timing.
+#   julia --project=gpu gpu/test_slices_e2e.jl
+# =============================================================================
+using StructureFunctions
+import KernelAbstractions as KA
+using CUDA, Printf
+using Statistics: median
+const SF = StructureFunctions
+const SFC = SF.Calculations
+const SFT = SF.StructureFunctionTypes
+using StructureFunctions: LinearBinEdges
+using StructureFunctions.Calculations:
+    serial_calculate_structure_functions_single_pass!,
+    serial_calculate_structure_functions_single_pass_2d!,
+    auxiliary_varying_positions!, auxiliary_joint2d!
+const FT = Float32
+const GPU_BE = SFC.GPUBackend(CUDA.CUDABackend())
+const sf2 = SFT.L2SFType()
+maxrel(a, b) = maximum(abs.(a .- b) ./ max.(abs.(b), 1f-3))
+
+println("Fused SLICES e2e on CUDA vs serial CPU\n")
+println("| case | bins | max relΔ | counts exact |")
+let N = 1500, T = 4
+    x = rand(FT, 2, N, T); u = randn(FT, 2, N, T)
+    lbe = LinearBinEdges(collect(range(0.05f0, 1.5f0; length = 17)))   # NB=16
+    NB = 16
+    # 1D individual slices
+    cs = zeros(FT, NB, T); cc = zeros(UInt32, NB, T)
+    auxiliary_varying_positions!(cs, cc, x, u, sf2, lbe)
+    gs = zeros(FT, NB, T); gc = zeros(UInt32, NB, T)
+    SFC.calculate_structure_function_slices!(gs, gc, sf2, x, u, lbe; backend = GPU_BE)
+    @printf("| ind slices | NB=%d | %.2e | %s |\n", NB, maxrel(gs, cs), gc == cc)
+    # SP1D slices
+    cs1 = zeros(FT, 6, NB, T); cc1 = zeros(UInt32, 6, NB, T)
+    serial_calculate_structure_functions_single_pass!(cs1, cc1, x, u, lbe)
+    gs1 = zeros(FT, 6, NB, T); gc1 = zeros(UInt32, 6, NB, T)
+    SFC.calculate_structure_functions_single_pass_slices!(gs1, gc1, x, u, lbe; backend = GPU_BE)
+    @printf("| SP1D slices | NB=%d | %.2e | %s |\n", NB, maxrel(gs1, cs1), gc1 == cc1)
+    # joint2d slices
+    ve = LinearBinEdges(collect(range(-0.5f0, 1.5f0; length = 21)))
+    nd = 16; nv = 20
+    cs2 = zeros(FT, nd, nv, T); cc2 = zeros(UInt32, nd, nv, T)
+    for b in 1:T
+        @views auxiliary_joint2d!(cs2[:, :, b], cc2[:, :, b], sf2, x[:, :, b], u[:, :, b], lbe, ve)
+    end
+    gs2 = zeros(FT, nd, nv, T); gc2 = zeros(UInt32, nd, nv, T)
+    SFC.calculate_structure_function_2d_slices!(gs2, gc2, sf2, x, u, lbe, ve; backend = GPU_BE)
+    @printf("| joint2d slices | %dx%d | %.2e | %s |\n", nd, nv, maxrel(gs2, cs2), gc2 == cc2)
+    # SP2D slices
+    nd2 = 16; nv2 = 20
+    cs3 = zeros(FT, 6, nd2, nv2, T); cc3 = zeros(UInt32, 6, nd2, nv2, T)
+    serial_calculate_structure_functions_single_pass_2d!(cs3, cc3, x, u, lbe, ve)
+    gs3 = zeros(FT, 6, nd2, nv2, T); gc3 = zeros(UInt32, 6, nd2, nv2, T)
+    SFC.calculate_structure_functions_single_pass_2d_slices!(gs3, gc3, x, u, lbe, ve; backend = GPU_BE)
+    @printf("| SP2D slices | %dx%d | %.2e | %s |\n", nd2, nv2, maxrel(gs3, cs3), gc3 == cc3)
+end
+
+println("\n--- slices timing N=20000, T=64 (wall-clock, public API) ---")
+let N = 20000, T = 64
+    x = rand(FT, 2, N, T); u = randn(FT, 2, N, T)
+    lbe = LinearBinEdges(collect(range(0.05f0, 1.5f0; length = 51)))   # NB=50
+    ve = LinearBinEdges(collect(range(-1.0f0, 1.0f0; length = 51)))    # nv=50
+    gs3 = zeros(FT, 6, 50, 50, T); gc3 = zeros(UInt32, 6, 50, 50, T)
+    f() = SFC.calculate_structure_functions_single_pass_2d_slices!(gs3, gc3, x, u, lbe, ve; backend = GPU_BE)
+    f(); f(); ts = Float64[]; for _ in 1:3; t = time_ns(); f(); push!(ts, (time_ns()-t)/1e9); end
+    t = median(ts)
+    @printf("  SP2D 50x50 slices: %.3f s @ T=%d  → T=8064 ≈ %.0f s\n", t, T, t*8064/T)
+end
+println("\nDONE_SLICES")

--- a/src/Calculations/gpu_stubs.jl
+++ b/src/Calculations/gpu_stubs.jl
@@ -1,5 +1,29 @@
 # GPU Extension and Workspace Stubs
 
+# ---------------------------------------------------------------------------
+# CUDA fast-path dispatch hooks (overridden by StructureFunctionsCUDAExt)
+# ---------------------------------------------------------------------------
+# The GPU (KernelAbstractions) extension calls these at its unified launch
+# chokepoints. The default returns `false` ("not handled") so portable KA
+# kernels run on CPU/AMD/whenever CUDA is not loaded. When both
+# KernelAbstractions and CUDA are loaded, StructureFunctionsCUDAExt adds
+# methods specialized on `CUDA.CUDABackend` that launch the N-body broadcast +
+# (for 2D) dynamic-shared kernels and return `true`. See
+# gpu/OPTIMAL_KERNEL_DESIGN.md for the settled design.
+
+"""Try the CUDA fast 2D launch (N-body broadcast + privatized histogram, dynamic
+shared for large single-pass). Returns `true` if handled, `false` to fall back to
+the portable KA tiled kernel. Overridden by `StructureFunctionsCUDAExt`."""
+gpu_fast_launch_2d_batch!(backend, out, cnt, x, u, sf_type, dist_dig, val_plan,
+                          N, n_dist, n_val, B, D, nmom, fixed_x) = false
+
+"""Try the CUDA fast 1D launch (N-body broadcast + privatized shared histogram).
+Returns `true` if handled, `false` to fall back to the portable KA tiled kernel.
+Overridden by `StructureFunctionsCUDAExt`."""
+gpu_fast_launch_1d_batch!(backend, out, cnt, x, u, sf_type, dist_dig,
+                          N, NB, B, D, nmom, fixed_x) = false
+
+
 """
     GPUSFWorkspace(backend, distance_bins; kind=:sf1d)
 

--- a/src/Calculations/serial_single_pass.jl
+++ b/src/Calculations/serial_single_pass.jl
@@ -196,23 +196,21 @@ function _accumulate_single_pass_1d!(
                 u_j = SA.SVector{D, FT2}(ntuple(d -> u[d, j], vD))
                 du = u_j - u_i
 
-                # Use multiple dispatch to avoid duplicate vector subtraction and sqrt/norm where possible
                 rh = SFH.r̂(x_i, x_j, distance_metric, r)
                 du_L = LA.dot(du, rh)
-                du_T = SFH.mδu_t(du, rh)
-
                 du_L2 = du_L * du_L
-                du_T2 = SFH.transverse_norm2(du, rh)
+                du_norm2 = LA.dot(du, du)
+                du_T2 = du_norm2 - du_L2
 
-                @inbounds sums[1, bin_idx] += du_L2 + du_T2
+                @inbounds sums[1, bin_idx] += du_norm2
                 @inbounds sums[2, bin_idx] += du_L2
                 @inbounds sums[3, bin_idx] += du_T2
-                @inbounds sums[4, bin_idx] += du_L * (du_L2 + du_T2)
+                @inbounds sums[4, bin_idx] += du_L * du_norm2
                 @inbounds sums[5, bin_idx] += du_L * du_L2
                 @inbounds sums[6, bin_idx] += du_L * du_T2
 
-                for t in 1:SINGLE_PASS_N
-                    @inbounds counts[t, bin_idx] += 1
+                @inbounds for t in 1:SINGLE_PASS_N
+                    counts[t, bin_idx] += one(CT)
                 end
             end
         end
@@ -511,16 +509,15 @@ function _accumulate_single_pass_2d!(
 
                 rh = SFH.r̂(x_i, x_j, distance_metric, r)
                 du_L = LA.dot(du, rh)
-                du_T = SFH.mδu_t(du, rh)
-
                 du_L2 = du_L * du_L
-                du_T2 = SFH.transverse_norm2(du, rh)
+                du_norm2 = LA.dot(du, du)
+                du_T2 = du_norm2 - du_L2
 
                 vals = (
-                    du_L2 + du_T2,
+                    du_norm2,
                     du_L2,
                     du_T2,
-                    du_L * (du_L2 + du_T2),
+                    du_L * du_norm2,
                     du_L * du_L2,
                     du_L * du_T2,
                 )

--- a/test/test_batch_matrix.jl
+++ b/test/test_batch_matrix.jl
@@ -59,6 +59,20 @@ Test.@testset "batch matrix parity (KA.CPU)" begin
         @test batch_histograms_equal(gpu_out.sums, gpu_out.counts, cpu_s, cpu_c; atol = 1f-4)
     end
 
+    @testset "row1b individual 1D fixed-x B>strip (regression)" begin
+        Nb, Bb = 24, 17
+        x, u, lbe = _rand_batch_fixed(Nb, Bb)
+        NB = length(lbe.edges) - 1
+        cpu_s = zeros(Float32, NB, Bb)
+        cpu_c = zeros(UInt32, NB, Bb)
+        auxiliary_shared_positions!(cpu_s, cpu_c, x, u, SF_TYPE, lbe)
+        gpu_out = SFC.calculate_structure_function(
+            SF_TYPE, x, u, lbe;
+            backend = GPU_BE, return_sums_and_counts = true, verbose = false,
+        )
+        @test batch_histograms_equal(gpu_out.sums, gpu_out.counts, cpu_s, cpu_c; atol = 1f-4)
+    end
+
     @testset "row2 individual 1D varying-x" begin
         x, u, lbe = _rand_batch_varying(N, B)
         @test ndims(x) == 3
@@ -157,5 +171,23 @@ Test.@testset "batch matrix parity (KA.CPU)" begin
             SF_TYPE, x, u, lbe, val_edges; backend = GPU_BE,
         )
         @test batch_histograms_equal(gpu_out.sums, gpu_out.counts, cpu_s, cpu_c; atol = 1f-4)
+    end
+
+    @testset "row8 SP2D fixed-x production 50x50 bin grid (smoke)" begin
+        Np, Bp = 32, 2
+        x, u, lbe = _rand_batch_fixed(Np, Bp)
+        val_edges = LinearBinEdges(collect(range(-1.0f0, 1.0f0; length = 51)))
+        @test length(lbe.edges) - 1 == 10
+        @test length(val_edges.edges) - 1 == 50
+        n_bins = length(lbe.edges) - 1
+        n_val = length(val_edges.edges) - 1
+        cpu_s = zeros(Float32, 6, n_bins, n_val, Bp)
+        cpu_c = zeros(UInt32, 6, n_bins, n_val, Bp)
+        serial_calculate_structure_functions_single_pass_2d!(cpu_s, cpu_c, x, u, lbe, val_edges)
+
+        gpu_sp = SFC.calculate_structure_functions_single_pass_2d(
+            x, u, lbe, val_edges; backend = GPU_BE,
+        )
+        @test batch_histograms_equal(gpu_sp.sums, gpu_sp.counts, cpu_s, cpu_c; atol = 1f-4)
     end
 end

--- a/test/test_gpu_tiled_parity.jl
+++ b/test/test_gpu_tiled_parity.jl
@@ -155,12 +155,12 @@ Test.@testset "GPU joint 2D parity — L3SF log distance bins" begin
     Test.@test gpu.sums ≈ ref.sums atol = 1e-10
 end
 
-Test.@testset "GPU tiled parity — NB > 64 errors" begin
+Test.@testset "GPU tiled parity — NB > SF_GPU_MAX_BINS errors" begin
     N = 20
     FT = Float64
     x = rand(FT, 2, N)
     u = rand(FT, 2, N)
-    bin_edges = collect(FT, range(0.0, 2.0; length = 67))  # 66 bins
+    bin_edges = collect(FT, range(0.0, 2.0; length = 130))  # 129 bins (> 128 cap)
     sft = SFT.L2SFType()
     Test.@test_throws ErrorException SFC.gpu_calculate_structure_function(
         sft, KA.CPU(), x, u, bin_edges; return_sums_and_counts = true,


### PR DESCRIPTION
## Summary

Rewrites the performance-critical GPU structure-function kernels around the **N-body broadcast** structure (each thread owns a point and loops the staged tile so all lanes read the same shared element — no per-pair sqrt-decode, no bank conflict), with a new CUDA-specialized extension and **measured per-regime dispatch**.

Validated against the serial/CPU reference and benchmarked head-to-head on A100 (jobs 238837/238895/239150/239164/239175).

## Headline

| path | before | after |
|------|--------|-------|
| **2D single-pass 50×50 fixed-x** @ B=8064 | ~974 s | **~58 s (~17×)** |
| 1D individual varying-x | 61 bapps | 115 bapps (**1.9×**) |
| SP1D (fixed+varying) | 30 bapps | 43 bapps (**1.4×**; beats 6× separate) |

## What changed

- **New `StructureFunctionsCUDAExt = ["KernelAbstractions","CUDA"]`** (`ext/cuda/kernels_{1d,2d}.jl`): static-shared privatized 1D histogram; dynamic-shared (`CuDynamicSharedArray`, 163 KB opt-in) privatized 2D histogram, TILE=1024. Overrides package stubs `gpu_fast_launch_{1d,2d}_batch!` on `::CUDABackend`; the portable KA kernels remain the CPU/AMD fallback. CUDA-only intrinsics not exposed by KernelAbstractions motivate the separate extension.
- **Regime-optimal routing** (the optimum is regime-dependent — "one kernel for all" is not fastest): 1D-individual-fixed-x → old global-warp-replica kernel (wins the tiny-histogram contention-bound regime, 147 vs 115 bapps); everything else → N-body.
- **Batch and time-series slices** both fuse into a single launch (no per-slice loop). Non-batch (B=1, sub-10 ms) left on the existing tiled128 path.

## Validation

- Exact integer counts vs CPU across all regimes; sums within FP32 reduction-order.
- **Full test suite green: 4374/4374.**

## Docs

`gpu/OPTIMAL_KERNEL_DESIGN.md` records the design, final routing table, all measured numbers, every ruled-out approach with its evidence, and the GPU compile pitfalls. Validation scripts kept under `gpu/` (`test_cuda_*`, `test_*_e2e`, `bench_1d_*`).